### PR TITLE
Remove `future` (Drop py2 compatability), fixes DeprecatedWarning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Goal
 -  Able to extract data for all the popular TLDs (com, org, net, ...)
 -  Query a WHOIS server directly instead of going through an
    intermediate web service like many others do.
--  Works with Python 2 & 3
+-  Works with Python 3 (Python 2 compatibility was dropped after 0.7.2)
 
 
 
@@ -47,24 +47,10 @@ Or checkout latest version from repository:
 
     $ git clone git@github.com:richardpenman/pywhois.git
 
-Note that then you will need to manually install the futures module, which allows supporting both Python 2 & 3:
-
-
-.. sourcecode:: bash
-
-    $ pip install futures
-
-Run test cases for python 2 & 3:
+Run test cases for python 3:
 
 .. sourcecode:: bash
 
-    $ python -m unittest discover test
-    .............
-    ----------------------------------------------------------------------
-    Ran 13 tests in 0.812s
-    
-    OK
-    
     $ python3 -m unittest discover test
     .............
     ----------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ setuptools.setup(
     version=version,
     description="Whois querying and parsing of domain registration information.",
     long_description='',
-    install_requires=[
-        'future',
-    ],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -18,7 +15,6 @@ setuptools.setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ],
     keywords='whois, python',

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 from whois import extract_domain

--- a/test/test_nicclient.py
+++ b/test/test_nicclient.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 from whois.whois import NICClient

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -3,8 +3,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 from whois import whois

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import re
 import sys

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -10,16 +10,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
 
 import re
 from datetime import datetime
 import json
-from past.builtins import basestring
 from builtins import str
 from builtins import *
 
-standard_library.install_aliases()
 
 try:
     import dateutil.parser as dp
@@ -152,7 +149,7 @@ class WhoisEntry(dict):
 
     def _preprocess(self, attr, value):
         value = value.strip()
-        if value and isinstance(value, basestring) and not value.isdigit() and '_date' in attr:
+        if value and isinstance(value, (bytes, str)) and not value.isdigit() and '_date' in attr:
             # try casting to date format
             value = cast_date(
                 value,
@@ -932,7 +929,7 @@ class WhoisBr(WhoisEntry):
 
     def _preprocess(self, attr, value):
         value = value.strip()
-        if value and isinstance(value, basestring) and '_date' in attr:
+        if value and isinstance(value,  (bytes, str)) and '_date' in attr:
             # try casting to date format
             value = re.findall(r"[\w\s:.-\\/]+", value)[0].strip()
             value = cast_date(

--- a/whois/time_zones.py
+++ b/whois/time_zones.py
@@ -2,8 +2,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 _tz_string = '''-12 Y
 -11 X NUT SST

--- a/whois/whois.py
+++ b/whois/whois.py
@@ -31,7 +31,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
 
 import os
 import optparse
@@ -40,7 +39,6 @@ import sys
 import re
 from builtins import object
 from builtins import *
-standard_library.install_aliases()
 
 
 class NICClient(object):


### PR DESCRIPTION
Fixes richardpenman/pywhois#38 by removing `future` (Thereby dropping support for python 2)

Testing: I get two failues, just like master (`test_com_allsamples` and `test_dk_parse`) but the number of attributes that are wrong is (inadvertedly) decreased from 8/250 to 6/250 for `test_com_allsamples` and it is the same (1/9) for `test_dk_parse`.