### PR TITLE
Add support for .chat tld.

### DIFF
--- a/whois/whois.py
+++ b/whois/whois.py
@@ -88,6 +88,7 @@ class NICClient(object):
     PE_HOST = "kero.yachay.pe"
     ONLINE_HOST = "whois.nic.online"
     IST_HOST = "whois.afilias-srs.net"
+    CHAT_HOST = "whois.nic.chat"
 
     WHOIS_RECURSE = 0x01
     WHOIS_QUICK = 0x02
@@ -251,6 +252,8 @@ class NICClient(object):
             return NICClient.IST_HOST
         elif tld == 'kz':
             return NICClient.KZ_HOST
+        elif tld == 'chat':
+            return NICClient.CHAT_HOST
         else:
             return tld + NICClient.QNICHOST_TAIL
 


### PR DESCRIPTION
Without this, the library throws a connection error.