### PR TITLE
Add elif TLD WHOIS.VE faltantes

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -347,6 +347,18 @@ class WhoisEntry(dict):
             return WhoisTr(domain, text)
         elif domain.endswith('.ve'):
             return WhoisVe(domain, text)
+        elif domain.endswith('co.ve'):
+            return WhoisVe(domain, text)
+        elif domain.endswith('com.ve'):
+            return WhoisVe(domain, text)
+        elif domain.endswith('web.ve'):
+            return WhoisVe(domain, text)
+        elif domain.endswith('org.ve'):
+            return WhoisVe(domain, text)
+        elif domain.endswith('edu.ve'):
+            return WhoisVe(domain, text)    
+        elif domain.endswith('net.ve'):
+            return WhoisVe(domain, text)   
         elif domain.endswith('.ua'):
             return WhoisUA(domain, text)
         elif domain.endswith('.kz'):


### PR DESCRIPTION
El whois de nic.ve no cambia para los TLD faltantes, con agregar el if faltante seguira arrojando el resultado correcto para los otros TLD.

Asi se mantiene la misma funcion.



The nic.ve whois does not change for the missing TLDs, adding the missing if will still return the correct result for the other TLDs.

Thus the same function is maintained.