### PR TITLE
Supply a 'quiet' argument to 'whois_lookup'

### DIFF
--- a/whois/whois.py
+++ b/whois/whois.py
@@ -275,11 +275,12 @@ class NICClient(object):
             return tld + NICClient.QNICHOST_TAIL
         
 
-    def whois_lookup(self, options, query_arg, flags):
+    def whois_lookup(self, options, query_arg, flags, quiet=False):
         """Main entry point: Perform initial lookup on TLD whois server,
         or other server to get region-specific whois server, then if quick
         flag is false, perform a second lookup on the region-specific
-        server for contact records"""
+        server for contact records.  If `quiet` is `True`, no message
+        will be printed to STDOUT when a socket error is encountered."""
         nichost = None
         # whoud happen when this function is called by other than main
         if options is None:
@@ -296,16 +297,17 @@ class NICClient(object):
             result = self.whois(
                 query_arg,
                 options['country'] + NICClient.QNICHOST_TAIL,
-                flags
+                flags,
+                quiet=quiet,
             )
         elif self.use_qnichost:
             nichost = self.choose_server(query_arg)
             if nichost is not None:
-                result = self.whois(query_arg, nichost, flags)
+                result = self.whois(query_arg, nichost, flags, quiet=quiet)
             else:
                 result = ''
         else:
-            result = self.whois(query_arg, options['whoishost'], flags)
+            result = self.whois(query_arg, options['whoishost'], flags, quiet=quiet)
         return result
 
 


### PR DESCRIPTION
Hello!  My PR #77 added in a `quiet` parameter to `NICClient.whois` -- this one exposes that boolean up to `NICClient.whois_lookup` as well.  I've written a whois-monitoring script using python-whois which should ideally only generate output on certain circumstances, so it'd be useful to have `quiet` available there.  (The project, FYI: https://github.com/apocalyptech/pywhoishistory)

Thanks!

-CJ