### PR TITLE
[Chore] Update repo paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Or checkout latest version from repository:
 
 .. sourcecode:: bash
 
-    $ git clone git@github.com:richardpenman/pywhois.git
+    $ git clone git@github.com:richardpenman/whois.git
 
 Note that then you will need to manually install the futures module, which allows supporting both Python 2 & 3:
 
@@ -88,7 +88,7 @@ Problems?
 Pull requests are welcome! 
 
 Thanks to the many who have sent patches for additional TLDs. If you want to add or fix a TLD it's quite straightforward. 
-See example domains in `whois/parser.py <https://github.com/richardpenman/pywhois/blob/master/whois/parser.py>`_
+See example domains in `whois/parser.py <https://github.com/richardpenman/whois/blob/master/whois/parser.py>`_
 
 Basically each TLD has a similar format to the following:
 

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -3,7 +3,7 @@
 # parser.py - Module for parsing whois response data
 # Copyright (c) 2008 Andrey Petrov
 #
-# This module is part of pywhois and is released under
+# This module is part of python-whois and is released under
 # the MIT license: http://www.opensource.org/licenses/mit-license.php
 
 from __future__ import absolute_import


### PR DESCRIPTION
GitHub redirects from [richardpenman/pywhois](https://github.com/richardpenman/pywhois) to [richardpenman/whois](https://github.com/richardpenman/whois). This change updates the repository path and title accordingly.