### PR TITLE
Use whois.nic.<tld> when <tld>.whois-servers.net does not exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(filename):
 
 setuptools.setup(
     name='python-whois',
-    version='0.8.1',
+    version='0.8.2',
     description="Whois querying and parsing of domain registration information.",
     long_description=read('README.rst'),
     install_requires=[

--- a/whois/whois.py
+++ b/whois/whois.py
@@ -96,6 +96,7 @@ class NICClient(object):
     PE_HOST = "kero.yachay.pe"
     PNICHOST = "whois.apnic.net"
     QNICHOST_TAIL = ".whois-servers.net"
+    QNICHOST_HEAD = "whois.nic."
     RNICHOST = "whois.ripe.net"
     SNICHOST = "whois.6bone.net"
     WEBSITE_HOST = "whois.nic.website"
@@ -287,7 +288,12 @@ class NICClient(object):
         elif tld == 'za':
             return NICClient.ZA_HOST
         else:
-            return tld + NICClient.QNICHOST_TAIL
+            server = tld + NICClient.QNICHOST_TAIL
+            try:
+                socket.gethostbyname(server)
+            except socket.gaierror:
+                server = NICClient.QNICHOST_HEAD + tld
+            return server
         
 
     def whois_lookup(self, options, query_arg, flags, quiet=False):


### PR DESCRIPTION
This fixes the issue with some "new" TLDs currently not working. Example : go.live, swarm.space, okbeauty.store , etc...

Close #134 