### PR TITLE
Remove Python2 support and fix a few parser tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setuptools.setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ],
     keywords='whois, python',

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,12 +1,3 @@
-# coding=utf-8
-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import *
 import unittest
 from whois import extract_domain
 

--- a/test/test_nicclient.py
+++ b/test/test_nicclient.py
@@ -1,12 +1,3 @@
-# coding=utf-8
-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import *
 import unittest
 from whois.whois import NICClient
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -237,7 +237,7 @@ DNSSEC: unsigned
             'billing_phone': '+1.2083895740',
             'billing_postal_code': '83646',
             'billing_state': 'Idaho',
-            'creation_date': datetime.datetime(2017, 12, 16, 5, 37, 20, 801000),
+            'creation_date': str(datetime.datetime(2017, 12, 16, 5, 37, 20, 801000)),
             'domain_id': '325702_nic_ai',
             'domain_name': 'google.ai',
             'name_servers': ['ns3.zdns.google',

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,27 +1,13 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import *
-import unittest
-
+import datetime
+import json
 import os
 import sys
-sys.path.append('../')
-
-import datetime
-
-try:
-    import json
-except:
-    import simplejson as json
+import unittest
 from glob import glob
 
-from whois.parser import WhoisEntry, cast_date, WhoisCl, WhoisAr, WhoisBy, \
-    WhoisCa, WhoisBiz, WhoisCr, WhoisDe, WhoisNl
+sys.path.append('../')
+
+from whois.parser import WhoisEntry, cast_date, WhoisCa
 
 
 class TestParser(unittest.TestCase):
@@ -57,8 +43,8 @@ class TestParser(unittest.TestCase):
                         'registrar', 'registrar_url', 'creation_date', 'status']
         fail = 0
         total = 0
-        whois_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),'samples','whois','*')
-        expect_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'samples','expected')
+        whois_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'samples', 'whois', '*')
+        expect_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'samples', 'expected')
         for path in glob(whois_path):
             # Parse whois data
             domain = os.path.basename(path)
@@ -78,14 +64,15 @@ class TestParser(unittest.TestCase):
                         return str(obj)
                     raise TypeError(
                             '{} is not JSON serializable'.format(repr(obj)))
+
                 outfile_name = os.path.join(expect_path, domain)
                 with open(outfile_name, 'w') as outfil:
                     expected_results = json.dump(results, outfil,
-                                                       default=date2str4json)
+                                                 default=date2str4json)
                 continue
 
             # Load expected result
-            with open(os.path.join(expect_path, domain)) as infil:    
+            with open(os.path.join(expect_path, domain)) as infil:
                 expected_results = json.load(infil)
 
             # Compare each key
@@ -95,7 +82,7 @@ class TestParser(unittest.TestCase):
             for key in compare_keys:
                 total += 1
                 if key not in results:
-                    print("%s \t(%s):\t Missing in results" % (domain, key,))
+                    print(f"{domain} \t({key}):\t Missing in results")
                     fail += 1
                     continue
 
@@ -106,12 +93,11 @@ class TestParser(unittest.TestCase):
                     result = str(result)
                 expected = expected_results.get(key)
                 if expected != result:
-                    print("%s \t(%s):\t %s != %s" % (domain, key, result, expected))
+                    print(f"{domain} \t({key}):\t {result} != {expected}")
                     fail += 1
 
         if fail:
-            self.fail("%d/%d sample whois attributes were not parsed properly!"
-                      % (fail, total))
+            self.fail(f"{fail}/{total} sample whois attributes were not parsed properly!")
 
     def test_ca_parse(self):
         data = """
@@ -233,54 +219,53 @@ DNSSEC: unsigned
         """
 
         expected_results = {
-             'admin_address': '1600 Amphitheatre Parkway',
-             'admin_city': 'Mountain View',
-             'admin_country': 'US',
-             'admin_email': 'dns-admin@google.com',
-             'admin_name': 'Domain Administrator',
-             'admin_org': 'Google LLC',
-             'admin_phone': '+1.6502530000',
-             'admin_postal_code': '94043',
-             'admin_state': 'CA',
-             'billing_address': ['3540 East Longwing Lane', 'Suite 300'],
-             'billing_city': 'Meridian',
-             'billing_country': 'US',
-             'billing_email': 'ccopsbilling@markmonitor.com',
-             'billing_name': 'CCOPS Billing',
-             'billing_org': 'MarkMonitor Inc.',
-             'billing_phone': '+1.2083895740',
-             'billing_postal_code': '83646',
-             'billing_state': 'Idaho',
-             'creation_date': datetime.datetime(2017, 12, 16, 5, 37, 20, 801000),
-             'domain_id': '325702_nic_ai',
-             'domain_name': 'google.ai',
-             'name_servers': ['ns3.zdns.google',
-                              'ns4.zdns.google',
-                              'ns1.zdns.google',
-                              'ns2.zdns.google'],
-             'registrant_address': '1600 Amphitheatre Parkway',
-             'registrant_city': 'Mountain View',
-             'registrant_country': 'US',
-             'registrant_email': 'dns-admin@google.com',
-             'registrant_name': 'Domain Administrator',
-             'registrant_org': 'Google LLC',
-             'registrant_phone': '+1.6502530000',
-             'registrant_postal_code': '94043',
-             'registrant_state': 'CA',
-             'registrar': 'Markmonitor',
-             'registrar_email': 'ccops@markmonitor.com',
-             'registrar_phone': '+1.2083895740',
-             'tech_address': '1600 Amphitheatre Parkway',
-             'tech_city': 'Mountain View',
-             'tech_country': 'US',
-             'tech_email': 'dns-admin@google.com',
-             'tech_name': 'Domain Administrator',
-             'tech_org': 'Google LLC',
-             'tech_phone': '+1.6502530000',
-             'tech_postal_code': '94043',
-             'tech_state': 'CA'}
+            'admin_address': '1600 Amphitheatre Parkway',
+            'admin_city': 'Mountain View',
+            'admin_country': 'US',
+            'admin_email': 'dns-admin@google.com',
+            'admin_name': 'Domain Administrator',
+            'admin_org': 'Google LLC',
+            'admin_phone': '+1.6502530000',
+            'admin_postal_code': '94043',
+            'admin_state': 'CA',
+            'billing_address': ['3540 East Longwing Lane', 'Suite 300'],
+            'billing_city': 'Meridian',
+            'billing_country': 'US',
+            'billing_email': 'ccopsbilling@markmonitor.com',
+            'billing_name': 'CCOPS Billing',
+            'billing_org': 'MarkMonitor Inc.',
+            'billing_phone': '+1.2083895740',
+            'billing_postal_code': '83646',
+            'billing_state': 'Idaho',
+            'creation_date': datetime.datetime(2017, 12, 16, 5, 37, 20, 801000),
+            'domain_id': '325702_nic_ai',
+            'domain_name': 'google.ai',
+            'name_servers': ['ns3.zdns.google',
+                             'ns4.zdns.google',
+                             'ns1.zdns.google',
+                             'ns2.zdns.google'],
+            'registrant_address': '1600 Amphitheatre Parkway',
+            'registrant_city': 'Mountain View',
+            'registrant_country': 'US',
+            'registrant_email': 'dns-admin@google.com',
+            'registrant_name': 'Domain Administrator',
+            'registrant_org': 'Google LLC',
+            'registrant_phone': '+1.6502530000',
+            'registrant_postal_code': '94043',
+            'registrant_state': 'CA',
+            'registrar': 'Markmonitor',
+            'registrar_email': 'ccops@markmonitor.com',
+            'registrar_phone': '+1.2083895740',
+            'tech_address': '1600 Amphitheatre Parkway',
+            'tech_city': 'Mountain View',
+            'tech_country': 'US',
+            'tech_email': 'dns-admin@google.com',
+            'tech_name': 'Domain Administrator',
+            'tech_org': 'Google LLC',
+            'tech_phone': '+1.6502530000',
+            'tech_postal_code': '94043',
+            'tech_state': 'CA'}
         self._parse_and_compare('google.ai', data, expected_results)
-
 
     def test_cn_parse(self):
         data = """
@@ -486,20 +471,20 @@ DNSSEC: signedDelegation
             "tech_id": "JM474-IEDR"
         }
         expected_results = {
-          "status": "ok https://icann.org/epp#ok",
-          "expiration_date": "2025-03-31 13:20:07",
-          "creation_date": "2000-02-11 00:00:00",
-          "domain_name": "rte.ie",
-          "tech_id": "3159-IEDR",
-          "registrar": "Blacknight Solutions",
-          "name_servers": [
-            "ns1.rte.ie",
-            "ns2.rte.ie",
-            "ns3.rte.ie",
-            "ns4.rte.ie"
-          ],
-          "admin_id": "202753-IEDR",
-          "registrar_contact": "abuse@blacknight.com"
+            "status": "ok https://icann.org/epp#ok",
+            "expiration_date": "2025-03-31 13:20:07",
+            "creation_date": "2000-02-11 00:00:00",
+            "domain_name": "rte.ie",
+            "tech_id": "3159-IEDR",
+            "registrar": "Blacknight Solutions",
+            "name_servers": [
+                "ns1.rte.ie",
+                "ns2.rte.ie",
+                "ns3.rte.ie",
+                "ns4.rte.ie"
+            ],
+            "admin_id": "202753-IEDR",
+            "registrar_contact": "abuse@blacknight.com"
         }
         self._parse_and_compare('rte.ie', data, expected_results)
 
@@ -617,7 +602,7 @@ Hostname:             p.nic.dk
 
     def _parse_and_compare(self, domain_name, data, expected_results, whois_entry=WhoisEntry):
         results = whois_entry.load(domain_name, data)
-        if domain_name=='google.ai':
+        if domain_name == 'google.ai':
             print(results)
         fail = 0
         total = 0
@@ -629,11 +614,10 @@ Hostname:             p.nic.dk
                 result = str(result)
             expected = expected_results.get(key)
             if expected != result:
-                print("%s \t(%s):\t %s != %s" % (domain_name, key, result, expected))
+                print(f"{domain_name} \t({key}):\t {result} != {expected}")
                 fail += 1
         if fail:
-            self.fail("%d/%d sample whois attributes were not parsed properly!"
-                      % (fail, total))
+            self.fail(f"{fail}/{total} sample whois attributes were not parsed properly!")
 
     def test_sk_parse(self):
         data = """

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,13 +1,5 @@
-# coding=utf-8
-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import *
 import unittest
+
 from whois import whois
 
 

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -1,21 +1,12 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
-from builtins import *
-import re
-import sys
+import logging
 import os
-import subprocess
+import re
 import socket
+import subprocess
+import sys
+
 from .parser import WhoisEntry
 from .whois import NICClient
-import logging
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -56,6 +47,8 @@ def whois(url, command=False, flags=0, executable="whois", inc_raw=False, quiet=
 
 
 suffixes = None
+
+
 def extract_domain(url):
     """Extract the domain from the given URL
 
@@ -107,7 +100,7 @@ def extract_domain(url):
             domain = b'.' + domain
         domain = section.encode('utf-8') + domain
         if domain not in suffixes:
-            if not b'.' in domain and len(split_url) >= 2:
+            if b'.' not in domain and len(split_url) >= 2:
                 # If this is the first section and there wasn't a match, try to
                 # match the first two sections - if that works, keep going
                 # See https://github.com/richardpenman/whois/issues/50
@@ -123,6 +116,6 @@ if __name__ == '__main__':
     try:
         url = sys.argv[1]
     except IndexError:
-        logger.error('Usage: %s url' % sys.argv[0])
+        logger.error(f'Usage: {sys.argv[0]} url')
     else:
         logger.info(whois(url))

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1,25 +1,12 @@
-# -*- coding: utf-8 -*-
-
 # parser.py - Module for parsing whois response data
 # Copyright (c) 2008 Andrey Petrov
 #
 # This module is part of python-whois and is released under
 # the MIT license: http://www.opensource.org/licenses/mit-license.php
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from future import standard_library
-
+import json
 import re
 from datetime import datetime
-import json
-from past.builtins import basestring
-from builtins import str
-from builtins import *
-
-standard_library.install_aliases()
 
 try:
     import dateutil.parser as dp
@@ -169,7 +156,7 @@ class WhoisEntry(dict):
 
     def _preprocess(self, attr, value):
         value = value.strip()
-        if value and isinstance(value, basestring) and not value.isdigit() and '_date' in attr:
+        if value and isinstance(value, str) and not value.isdigit() and '_date' in attr:
             # try casting to date format
             value = cast_date(
                 value,
@@ -422,7 +409,7 @@ class WhoisSG(WhoisEntry):
         techmatch = re.compile('Technical Contact:(.*?)Name Servers:', re.DOTALL).search(text)
         if techmatch:
             for line in techmatch.groups()[0].strip().splitlines():
-                self['technical_conatact_'+ line.split(':')[0].strip().lower()] = line.split(':')[1].strip()
+                self['technical_conatact_' + line.split(':')[0].strip().lower()] = line.split(':')[1].strip()
 
 
 class WhoisPe(WhoisEntry):
@@ -580,8 +567,8 @@ class WhoisNl(WhoisEntry):
             duplicate_nameservers_without_ip = [nameserver.split(' ')[0]
                                                 for nameserver in duplicate_nameservers_with_ip]
             self['name_servers'] = sorted(list(set(duplicate_nameservers_without_ip)))
-            
-            
+
+
 class WhoisLt(WhoisEntry):
     """Whois parser for .lt domains
         """
@@ -605,7 +592,7 @@ class WhoisLt(WhoisEntry):
                                              for line in match.groups()[0].strip().splitlines()]
             duplicate_nameservers_without_ip = [nameserver.split(' ')[0]
                                                 for nameserver in duplicate_nameservers_with_ip]
-            self['name_servers'] = sorted(list(set(duplicate_nameservers_without_ip)))            
+            self['name_servers'] = sorted(list(set(duplicate_nameservers_without_ip)))
 
 
 class WhoisName(WhoisEntry):
@@ -728,6 +715,7 @@ class WhoisPl(WhoisEntry):
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
+
 class WhoisGroup(WhoisEntry):
     """Whois parser for .group domains
     """
@@ -750,6 +738,7 @@ class WhoisGroup(WhoisEntry):
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
+
 
 class WhoisCa(WhoisEntry):
     """Whois parser for .ca domains
@@ -1050,7 +1039,7 @@ class WhoisBr(WhoisEntry):
 
     def _preprocess(self, attr, value):
         value = value.strip()
-        if value and isinstance(value, basestring) and '_date' in attr:
+        if value and isinstance(value, str) and '_date' in attr:
             # try casting to date format
             value = re.findall(r"[\w\s:.-\\/]+", value)[0].strip()
             value = cast_date(
@@ -1058,7 +1047,7 @@ class WhoisBr(WhoisEntry):
                 dayfirst=self.dayfirst,
                 yearfirst=self.yearfirst)
         return value
-        
+
 
 class WhoisKr(WhoisEntry):
     """Whois parser for .kr domains
@@ -1947,7 +1936,7 @@ class WhoisAi(WhoisEntry):
     """
     regex = {
         'domain_name':                      r'Domain Name\.*: *(.+)',
-        'domain_id' :                       r'Registry Domain ID\.*: *(.+)',
+        'domain_id':                       r'Registry Domain ID\.*: *(.+)',
         'creation_date':                    r'Creation Date: (.+)',
         'registrar':                        r'Registrar: (.+)',
         'registrar_phone':                  r'Registrar Abuse Contact Phone:(.+)',
@@ -2083,15 +2072,15 @@ class WhoisIe(WhoisEntry):
     """Whois parser for .ie domains
     """
     regex = {
-        'domain_name':      r'Domain Name: *(.+)',
-        'creation_date':    r'Creation Date: *(.+)',
-        'expiration_date':  r'Registry Expiry Date: *(.+)',
-        'name_servers':     r'Name Server: *(.+)',
-        'status':           r'Domain status: *(.+)',
-        'admin_id':         r'Registry Admin ID: *(.+)',
-        'tech_id':          r'Registry Tech ID: *(.+)',
-        'registrar':        r'Registrar: *(.+)',
-        'registrar_contact':r'Registrar Abuse Contact Email: *(.+)'
+        'domain_name':       r'Domain Name: *(.+)',
+        'creation_date':     r'Creation Date: *(.+)',
+        'expiration_date':   r'Registry Expiry Date: *(.+)',
+        'name_servers':      r'Name Server: *(.+)',
+        'status':            r'Domain status: *(.+)',
+        'admin_id':          r'Registry Admin ID: *(.+)',
+        'tech_id':           r'Registry Tech ID: *(.+)',
+        'registrar':         r'Registrar: *(.+)',
+        'registrar_contact': r'Registrar Abuse Contact Email: *(.+)'
     }
 
     def __init__(self, domain, text):
@@ -2829,8 +2818,8 @@ class WhoisKZ(WhoisEntry):
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
-            
-            
+
+
 class WhoisIR(WhoisEntry):
     """Whois parser for .ir domains."""
 
@@ -2869,8 +2858,8 @@ class WhoisZhongGuo(WhoisEntry):
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
-            
-            
+
+
 class WhoisWebsite(WhoisEntry):
     """Whois parser for .website domains
     """
@@ -2885,7 +2874,7 @@ class WhoisWebsite(WhoisEntry):
 class WhoisML(WhoisEntry):
     """Whois parser for .ml domains."""
     regex = {
-        'domain_name': r'Domain name:\s*([^(i|\n)]+)', 
+        'domain_name': r'Domain name:\s*([^(i|\n)]+)',
         'registrar': r'Organization: *(.+)',
         'creation_date': r'Domain registered: *(.+)',
         'expiration_date': r'Record will expire on: *(.+)',
@@ -2898,7 +2887,7 @@ class WhoisML(WhoisEntry):
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
-    
+
     def _preprocess(self, attr, value):
         if attr == 'name_servers':
             return [
@@ -2908,7 +2897,7 @@ class WhoisML(WhoisEntry):
             ]
         return super(WhoisML, self)._preprocess(attr, value)
 
-      
+
 class WhoisOoo(WhoisEntry):
     """Whois parser for .ooo domains
     """
@@ -2918,8 +2907,8 @@ class WhoisOoo(WhoisEntry):
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
-            
-            
+
+
 class WhoisMarket(WhoisEntry):
     """Whois parser for .market domains
     """

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -31,6 +31,7 @@ KNOWN_FORMATS = [
     '%Y%m%d %H:%M:%S',          # 20110908 14:44:51
     '%d/%m/%Y',                 # 02/01/2013
     '%Y. %m. %d.',              # 2000. 01. 02.
+    '%Y-%b-%d.',                # 2000-Aug-02.
     '%Y.%m.%d %H:%M:%S',        # 2014.03.08 10:28:24
     '%d-%b-%Y %H:%M:%S %Z',     # 24-Jul-2009 13:20:03 UTC
     '%a %b %d %H:%M:%S %Z %Y',  # Tue Jun 21 23:59:59 GMT 2011
@@ -371,8 +372,8 @@ class WhoisCl(WhoisEntry):
         'registrant_organization': r'Registrant organisation: *(.+)',
         'registrar': r'registrar name: *(.+)',
         'registrar_url': r'Registrar URL: *(.+)',
-        'creation_date': r'Creation date: *(.+)',
-        'expiration_date': r'Expiration date: *(.+)',
+        'creation_date': r'Creation date: *(.+) CLST',
+        'expiration_date': r'Expiration date: *(.+) CLST',
         'name_servers': r'Name server: *(.+)',  # list of name servers
     }
 
@@ -1127,7 +1128,7 @@ class WhoisDe(WhoisEntry):
     regex = {
         'domain_name':            r'Domain: *(.+)',
         'status':                 r'Status: *(.+)',
-        'updated_date':           r'Changed: *(.+)',
+        'updated_date':           r'Changed: *([^+]*)',
         'name':                   r'name: *(.+)',
         'org':                    r'Organisation: *(.+)',
         'address':                r'Address: *(.+)',
@@ -1936,7 +1937,7 @@ class WhoisAi(WhoisEntry):
     """
     regex = {
         'domain_name':                      r'Domain Name\.*: *(.+)',
-        'domain_id':                       r'Registry Domain ID\.*: *(.+)',
+        'domain_id':                        r'Registry Domain ID\.*: *(.+)',
         'creation_date':                    r'Creation Date: (.+)',
         'registrar':                        r'Registrar: (.+)',
         'registrar_phone':                  r'Registrar Abuse Contact Phone:(.+)',
@@ -2309,9 +2310,9 @@ class WhoisUA(WhoisEntry):
         'admin_phone':                   r'(?<=Administrative Contacts:)[\s\W\w]*?phone:(.*)',
         'admin_fax':                     r'(?<=Administrative Contacts:)[\s\W\w]*?fax:(.*)',
 
-        'updated_date':                   r'modified: *(.+)',
-        'creation_date':                  r'created: (.+)',
-        'expiration_date':                r'expires: (.+)',
+        'updated_date':                   r'modified: *([^+]*)',
+        'creation_date':                  r'created: ([^+]*)',
+        'expiration_date':                r'expires: ([^+]*)',
         'name_servers':                   r'nserver: *(.+)'
     }
 

--- a/whois/time_zones.py
+++ b/whois/time_zones.py
@@ -1,10 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import *
 _tz_string = '''-12 Y
 -11 X NUT SST
 -10 W CKT HAST HST TAHT TKT

--- a/whois/whois.py
+++ b/whois/whois.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Whois client for python
 
@@ -27,25 +25,19 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
 
 import os
 import optparse
 import socket
 import sys
 import re
-from builtins import object
-from builtins import *
+
 import logging
-standard_library.install_aliases()
 
 logger = logging.getLogger(__name__)
 
-class NICClient(object):
+
+class NICClient:
 
     ABUSEHOST = "whois.abuse.net"
     AI_HOST = "whois.nic.ai"
@@ -153,18 +145,16 @@ class NICClient(object):
             socksproxy, port = proxy.split(":")
             socks_proto = socket.AF_INET
             if socket.AF_INET6 in [sock[0] for sock in socket.getaddrinfo(socksproxy, port)]:
-                socks_proto=socket.AF_INET6
+                socks_proto = socket.AF_INET6
             s = socks.socksocket(socks_proto)
             s.set_proxy(socks.SOCKS5, socksproxy, int(port), True, socks_user, socks_password)
         else:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(10)
-        try: # socket.connect in a try, in order to allow things like looping whois on different domains without stopping on timeouts: https://stackoverflow.com/questions/25447803/python-socket-connection-exception
+        try:  # socket.connect in a try, in order to allow things like looping whois on different domains without stopping on timeouts: https://stackoverflow.com/questions/25447803/python-socket-connection-exception
             s.connect((hostname, 43))
             try:
                 query = query.decode('utf-8')
-            except UnicodeEncodeError:
-                pass  # Already Unicode (python2's error)
             except AttributeError:
                 pass  # Already Unicode (python3's error)
 
@@ -193,20 +183,18 @@ class NICClient(object):
                 nhost = self.findwhois_server(response, hostname, query)
             if nhost is not None:
                 response += self.whois(query, nhost, 0, quiet=True)
-        except socket.error as exc: # 'response' is assigned a value (also a str) even on socket timeout
+        except socket.error as exc:  # 'response' is assigned a value (also a str) even on socket timeout
             if not quiet:
-                logger.error("Error trying to connect to socket: closing socket - {}".format(exc))
+                logger.error(f"Error trying to connect to socket: closing socket - {exc}")
             s.close()
-            response = "Socket not responding: {}".format(exc)
+            response = f"Socket not responding: {exc}"
         return response
 
     def choose_server(self, domain):
         """Choose initial lookup NIC host"""
         try:
             domain = domain.encode('idna').decode('utf-8')
-        except TypeError:
-            domain = domain.decode('utf-8').encode('idna').decode('utf-8')
-        except AttributeError:
+        except (TypeError, AttributeError):
             domain = domain.decode('utf-8').encode('idna').decode('utf-8')
         if domain.endswith("-NORID"):
             return NICClient.NORIDHOST
@@ -294,7 +282,6 @@ class NICClient(object):
             except socket.gaierror:
                 server = NICClient.QNICHOST_HEAD + tld
             return server
-        
 
     def whois_lookup(self, options, query_arg, flags, quiet=False):
         """Main entry point: Perform initial lookup on TLD whois server,
@@ -344,37 +331,37 @@ def parse_command_line(argv):
     parser = optparse.OptionParser(add_help_option=False, usage=usage)
     parser.add_option("-a", "--arin", action="store_const",
                       const=NICClient.ANICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.ANICHOST)
+                      help=f"Lookup using host {NICClient.ANICHOST}")
     parser.add_option("-A", "--apnic", action="store_const",
                       const=NICClient.PNICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.PNICHOST)
+                      help=f"Lookup using host {NICClient.PNICHOST}")
     parser.add_option("-b", "--abuse", action="store_const",
                       const=NICClient.ABUSEHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.ABUSEHOST)
+                      help=f"Lookup using host {NICClient.ABUSEHOST}")
     parser.add_option("-c", "--country", action="store",
                       type="string", dest="country",
                       help="Lookup using country-specific NIC")
     parser.add_option("-d", "--mil", action="store_const",
                       const=NICClient.DNICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.DNICHOST)
+                      help=f"Lookup using host {NICClient.DNICHOST}")
     parser.add_option("-g", "--gov", action="store_const",
                       const=NICClient.GNICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.GNICHOST)
+                      help=f"Lookup using host {NICClient.GNICHOST}")
     parser.add_option("-h", "--host", action="store",
                       type="string", dest="whoishost",
                       help="Lookup using specified whois host")
     parser.add_option("-i", "--nws", action="store_const",
                       const=NICClient.INICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.INICHOST)
+                      help=f"Lookup using host {NICClient.INICHOST}")
     parser.add_option("-I", "--iana", action="store_const",
                       const=NICClient.IANAHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.IANAHOST)
+                      help=f"Lookup using host {NICClient.IANAHOST}")
     parser.add_option("-l", "--lcanic", action="store_const",
                       const=NICClient.LNICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.LNICHOST)
+                      help=f"Lookup using host {NICClient.LNICHOST}")
     parser.add_option("-m", "--ra", action="store_const",
                       const=NICClient.MNICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.MNICHOST)
+                      help=f"Lookup using host {NICClient.MNICHOST}")
     parser.add_option("-p", "--port", action="store",
                       type="int", dest="port",
                       help="Lookup using specified tcp port")
@@ -383,16 +370,16 @@ def parse_command_line(argv):
                       help="Perform quick lookup")
     parser.add_option("-r", "--ripe", action="store_const",
                       const=NICClient.RNICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.RNICHOST)
+                      help=f"Lookup using host {NICClient.RNICHOST}")
     parser.add_option("-R", "--ru", action="store_const",
                       const="ru", dest="country",
                       help="Lookup Russian NIC")
     parser.add_option("-6", "--6bone", action="store_const",
                       const=NICClient.SNICHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.SNICHOST)
+                      help=f"Lookup using host {NICClient.SNICHOST}")
     parser.add_option("-n", "--ina", action="store_const",
                       const=NICClient.PANDIHOST, dest="whoishost",
-                      help="Lookup using host " + NICClient.PANDIHOST)
+                      help=f"Lookup using host {NICClient.PANDIHOST}")
     parser.add_option("-?", "--help", action="help")
 
     return parser.parse_args(argv)


### PR DESCRIPTION
Hey there,

I tried to make the smallest footprint I could here for easy comparison.   I removed the extra pieces for Python 2 support in one commit and then fixed some tests that were failing.

The tests that were failing were failing prior to any changes on my part and they were mostly trivial regex adjustments.

My editor got rid of a lot of dangling whitespace.  If you want to compare these on Github I'd turn off the whitespace comparisons.   https://cloudfour.com/thinks/quick-tip-how-to-hide-whitespace-changes-in-git-diffs/   It's always a bother when I'm trying to shoot for the smallest delta I can.