### PR TITLE
Fixed check for .org domain again

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -504,7 +504,7 @@ class WhoisOrg(WhoisEntry):
     }
 
     def __init__(self, domain, text):
-        if text.strip().startswith('NOT FOUND'):
+        if text.strip().startswith('NOT FOUND') or text.strip().startswith('Domain not found'):
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text)


### PR DESCRIPTION
Whois server now returns "Domain not found" instead of "NOT FOUND" (but kept the old check for backward compatibility)