### PR TITLE
Add more fields for .au domains

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -957,6 +957,8 @@ class WhoisAU(WhoisEntry):
         'registrant_name':                r'Registrant: *(.+)',
         'registrant_contact_name':        r'Registrant Contact Name: (.+)',
         'name_servers':                   r'Name Server: *(.+)',
+        'registrant_id':                  r'Registrant ID: *(.+)',
+        'eligibility_type':               r'Eligibility Type: *(.+)',
     }
 
     def __init__(self, domain, text):


### PR DESCRIPTION
Adds support for the `Registrant ID` & `Eligibility Type` fields from auDA.

This is useful as `Registrant ID` will typically contain the ABN (Australian Business Number) that a domain is registered with. Similarly, `Eligibility Type` provides further details on the type of company, which could be useful.