### PR TITLE
Fixing format for .at and .be tld

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1195,11 +1195,15 @@ class WhoisAt(WhoisEntry):
 class WhoisBe(WhoisEntry):
     """Whois parser for .be domains"""
     regex = {
-        'name':     r'Name: *(.+)',
-        'org':      r'Organisation: *(.+)',
-        'phone':    r'Phone: *(.+)',
-        'fax':      r'Fax: *(.+)',
-        'email':    r'Email: *(.+)',
+        'domain_name':      r'Domain: *(.+)',
+        'status':           r'Status: *(.+)',
+        'name':             r'Name: *(.+)',
+        'org':              r'Organisation: *(.+)',
+        'phone':            r'Phone: *(.+)',
+        'fax':              r'Fax: *(.+)',
+        'email':            r'Email: *(.+)',
+        'creation_date':    r'Registered: *(.+)',
+        'name_servers':     r'Nameservers:\s((?:\s+?[\w.]+\s)*)'  # list of name servers
     }
 
     def __init__(self, domain, text):

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1172,6 +1172,7 @@ class WhoisAt(WhoisEntry):
     regex = {
         'domain_name':            r'domain: *(.+)',
         'registrar':              r'registrar: *(.+)',
+        'name_servers':           r'nserver: *(.+)',
         'name':                   r'personname: *(.+)',
         'org':                    r'organization: *(.+)',
         'address':                r'street address: *(.+)',


### PR DESCRIPTION
In the original code name_servers were not provided for .at and .be domains. In this fix it is added for both. Besides domain_name, status and creation_date has been added for .be.