### PR TITLE
Add 'before %Y-%m-%d' date format for nic.ch

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -71,6 +71,7 @@ KNOWN_FORMATS = [
     '%B %d %Y',                 # August 14 2017
     '%d.%m.%Y %H:%M:%S',        # 08.03.2014 10:28:24
     'before %b-%Y',             # before aug-1996
+    'before %Y-%m-%d',          # before 1996-01-01
     '%Y-%m-%d %H:%M:%S (%Z%z)'  # 2017-09-26 11:38:29 (GMT+00:00)
 ]
 


### PR DESCRIPTION
The .ch ccTLD uses a `before YYYY-MM-DD` date format for some domains, including its own `nic.ch`:

```
First registration date:
before 1996-01-01
```

This fix turns `'creation_date': 'before 1996-01-01'` into `'creation_date': datetime.datetime(1996, 1, 1, 0, 0)`.