### PR TITLE
Add parser support for .rs ccTLD WHOIS

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -392,6 +392,8 @@ class WhoisEntry(dict):
             return WhoisLife(domain, text)
         elif domain.endswith('.tn'):
             return WhoisTN(domain, text)
+        elif domain.endswith('.rs'):
+            return WhoisRs(domain, text)
         else:
             return WhoisEntry(domain, text)
 
@@ -969,6 +971,32 @@ class WhoisAU(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.strip() == 'No Data Found':
+            raise PywhoisError(text)
+        else:
+            WhoisEntry.__init__(self, domain, text, self.regex)
+
+
+class WhoisRs(WhoisEntry):
+    """Whois parser for .rs domains"""
+    _regex = {
+        'domain_name':            r'Domain name: *(.+)',
+        'status':                 r'Domain status: *(.+)',  # list of statuses
+        'creation_date':          r'Registration date: *(.+)',
+        'updated_date':           r'Modification date: *(.+)',
+        'expiration_date':        r'Expiration date: *(.+)',
+        'registrar':              r'Registrar: *(.+)',
+        'name':                   r'Registrant: *(.+)',
+        'address':                r'Registrant: *.+\nAddress: *(.+)',
+        'admin_name':             r'Administrative contact: *(.+)',
+        'admin_address':          r'Administrative contact: *.+\nAddress: *(.+)',
+        'tech_name':              r'Technical contact: *(.+)',
+        'tech_address':           r'Technical contact: *.+\nAddress: *(.+)',
+        'name_servers':           r'DNS: *(\S+)',  # list of name servers
+        'dnssec':                 r'DNSSEC signed: *(\S+)',
+    }
+
+    def __init__(self, domain, text):
+        if text.strip() == '%ERROR:103: Domain is not registered':
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)


### PR DESCRIPTION
Add support for .rs ccTLD WHOIS format.  Fixes #106.

Turns

```
>>> whois.whois('google.rs')
{'domain_name': 'google.rs', 'registrar': 'Webglobe d.o.o.', 'whois_server': None, 'referral_url': None, 'updated_date': None, 'creation_date': None, 'expiration_date': datetime.datetime(2024, 10, 3, 12, 31, 19), 'name_servers': None, 'status': ['Active https://www.rnids.rs/en/domain-name-status-codes#Active', 'clientUpdateProhibited https://www.rnids.rs/en/domain-name-status-codes#ClientUpdateProhibited'], 'emails': None, 'dnssec': None, 'name': None, 'org': None, 'address': None, 'city': None, 'state': None, 'registrant_postal_code': None, 'country': None}
```

into

```
>>> whois.whois('google.rs')
{'domain_name': 'google.rs', 'status': ['Active https://www.rnids.rs/en/domain-name-status-codes#Active', 'clientUpdateProhibited https://www.rnids.rs/en/domain-name-status-codes#ClientUpdateProhibited'], 'creation_date': datetime.datetime(2008, 10, 3, 12, 31, 19), 'updated_date': datetime.datetime(2023, 6, 2, 22, 22, 30), 'expiration_date': datetime.datetime(2024, 10, 3, 12, 31, 19), 'registrar': 'Webglobe d.o.o.', 'name': 'Google LLC', 'address': '1600 Amphitheatre Parkway, Mountain View, CA 94043, United States of America', 'admin_name': 'Drustvo za marketing Google DOO', 'admin_address': 'Marsala Birjuzova 47/18, Beograd, Serbia', 'tech_name': 'MarkMonitor, Inc.', 'tech_address': '3540 East Longwing Lane, Suite 300, Meridian, ID 83646, United States of America', 'name_servers': ['ns1.google.com', 'ns2.google.com', 'ns3.google.com', 'ns4.google.com'], 'dnssec': 'no'}
```