### PR TITLE
Add basic support for .gg

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -378,6 +378,8 @@ class WhoisEntry(dict):
             return WhoisBw(domain, text)
         elif domain.endswith('.bz'):
             return WhoisBz(domain, text)
+        elif domain.endswith('.gg'):
+            return WhoisGg(domain, text)
         elif domain.endswith('.city'):
             return WhoisCity(domain, text)
         elif domain.endswith('.design'):
@@ -3181,6 +3183,21 @@ class WhoisZa(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.startswith('Available'):
+            raise PywhoisError(text)
+        else:
+            WhoisEntry.__init__(self, domain, text, self.regex)
+
+
+class WhoisGg(WhoisEntry):
+    """Whois parser for .gg domains"""
+    regex = {
+        'domain_name':            r'Domain:\n +(.+)',
+        'registrar':              r'Registrar:\n\s+(.+)',
+        'creation_date':          r'Relevant dates:\n\s+Registered on (.+)',
+    }
+
+    def __init__(self, domain, text):
+        if 'NOT FOUND' in text:
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)


### PR DESCRIPTION
Turns:

```
>>> whois.whois('island.gg')
{'domain_name': None, 'registrar': None, 'whois_server': None, 'referral_url': None, 'updated_date': None, 'creation_date': None, 'expiration_date': None, 'name_servers': None, 'status': None, 'emails': None, 'dnssec': None, 'name': None, 'org': None, 'address': None, 'city': None, 'state': None, 'registrant_postal_code': None, 'country': None}
```

into

```
>>> whois.whois('island.gg')
{'domain_name': 'island.gg', 'registrar': 'Sav.com LLC (https://www.sav.com)', 'creation_date': datetime.datetime(2023, 3, 3, 0, 5, 14, 551000)}
```