### PR TITLE
Add very basic support for .edu domains

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -392,6 +392,8 @@ class WhoisEntry(dict):
             return WhoisLife(domain, text)
         elif domain.endswith('.tn'):
             return WhoisTN(domain, text)
+        elif domain.endswith('.edu'):
+            return WhoisEdu(domain, text)
         else:
             return WhoisEntry(domain, text)
 
@@ -3280,6 +3282,21 @@ class WhoisTN(WhoisEntry):
 
     def __init__(self, domain, text):
         if text.startswith('Available'):
+            raise PywhoisError(text)
+        else:
+            WhoisEntry.__init__(self, domain, text, self.regex)
+
+class WhoisEdu(WhoisEntry):
+    """Whois parser for .edu domains"""
+    regex = {
+        'domain_name':      'Domain name: *(.+)',
+        'creation_date':    'Domain record activated: *(.+)',
+        'lats_modified':    'Domain record last updated: *(.+)',
+        'expiration_date':  'Domain expires: *(.+)'
+    }
+
+    def __init__(self, domain, text):
+        if text.strip() == 'No entries found':
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)


### PR DESCRIPTION
I don't really code in Python, but this PR adds some basic support for `.edu` domains to parse the creation/expiration dates. Still requires additional later work for other fields.

Currently:
```
{'domain_name': 'SRU.EDU', 'registrar': None, 'whois_server': None, 'referral_url': None, 'updated_date': None, 'creation_date': None, 'expiration_date': None, 'name_servers': None, 'status': None, 'emails': None, 'dnssec': None, 'name': None, 'org': None, 'address': None, 'city': None, 'state': None, 'registrant_postal_code': None, 'country': None}
```

With this PR:
```
{'domain_name': 'SRU.EDU', 'creation_date': datetime.datetime(1993, 1, 20, 0, 0), 'expiration_date': datetime.datetime(2024, 7, 31, 0, 0)}
```