### PR TITLE
Add new date format.

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -71,6 +71,7 @@ KNOWN_FORMATS = [
     '%B %d %Y',                 # August 14 2017
     '%d.%m.%Y %H:%M:%S',        # 08.03.2014 10:28:24
     'before %b-%Y',             # before aug-1996
+    'before %Y%m%d',            # before 19960821
     '%Y-%m-%d %H:%M:%S (%Z%z)'  # 2017-09-26 11:38:29 (GMT+00:00)
 ]
 


### PR DESCRIPTION
**ipt.br** domain  returns:
```
{'domain_name': 'ipt.br',
 'registrant_name': 'Instituto Pesquisas Tecnol�gicas do Estado de S.P.',
 'registrant_id': None,
 'country': None,
 'owner_c': 'SAG125',
 'admin_c': None,
 'tech_c': 'GIB12',
 'billing_c': None,
 'name_server': ['dce01.ipt.br 200.18.53.33 2001:12f0:502:53::33',
  'gracco.ipt.br 200.18.53.54 2001:12f0:502:53::54'],
 'nsstat': '20231030 AA',
 'nslastaa': '20231030',
 'saci': None,
 'creation_date': ['before 19950101',
  datetime.datetime(2003, 9, 4, 0, 0),
  datetime.datetime(1998, 7, 8, 0, 0)],
 'updated_date': [datetime.datetime(2017, 10, 25, 0, 0),
  datetime.datetime(2020, 5, 4, 0, 0),
  datetime.datetime(2020, 11, 20, 0, 0)],
 'expiration_date': None,
 'status': 'published',
 'nic_hdl_br': ['SAG125', 'GIB12'],
 'person': ['Salvador Giaquinto', 'Gilson Bozolan'],
 'email': None}
```
So in order to parse `before 19950101`, a new format was added.
