### PR TITLE
fix design domain

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -3371,6 +3371,7 @@ class WhoisSite(WhoisEntry):
 
     def __init__(self, domain, text):
         if "DOMAIN NOT FOUND" in text:
+            raise PywhoisError(text)
 
           
 class WhoisEdu(WhoisEntry):


### PR DESCRIPTION
The .design domain already configured but was using "WhoisRuServer", but it was not working, I changed TLD to "whois.nic.design".

I tested with domain: "https://baht.design"