### PR TITLE
Fix KZ domain registrar, registrar created and not registered detection

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -3024,8 +3024,8 @@ class WhoisKZ(WhoisEntry):
     """Whois parser for .kz domains"""
     regex = {
         'domain_name':       r'Domain Name............: *(.+)',
-        'registrar_created': r'Registrar Created: *(.+)',
-        'current_registrar': r'Current Registrar: *(.+)',
+        'registrar_created': r'Registr?ar Created: *(.+)',
+        'registrar':         r'Current Registr?ar: *(.+)',
         'creation_date':     r'Domain created: *(.+)',
         'last_modified':     r'Last modified : *(.+)',
         'name_servers':      r'server.*: *(.+)',  # list of name servers
@@ -3035,7 +3035,7 @@ class WhoisKZ(WhoisEntry):
     }
 
     def __init__(self, domain, text):
-        if text.strip() == 'No entries found':
+        if '*** Nothing found for this query.' in text:
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)


### PR DESCRIPTION
Unbreaks currently broken KZ whois:

- They misspell registrar as registar in their WHOIS, reflect that in the regexes to actually pick up the registrars
- Rename `current_registrar` to `registrar` for consistency with other TLD results (avoids having to write TLD-specific code to handle different names for semantically the same thing)
- Fix check for non-existing domain name

(Also currently needs #192 to not fall over the syntax error still in master.)