### PR TITLE
Fixes for the parser and handling of .dk domains

### DIFF
--- a/build/lib/whois/parser.py
+++ b/build/lib/whois/parser.py
@@ -1991,6 +1991,7 @@ class WhoisDk(WhoisEntry):
         'domain_name':            r'Domain: *(.+)',
         'creation_date':          r'Registered: *(.+)',
         'expiration_date':        r'Expires: *(.+)',
+        'registrar':              r'Registrar: *(.+)',
         'dnssec':                 r'Dnssec: *(.+)',
         'status':                 r'Status: *(.+)',
         'registrant_handle':      r'Registrant\s*(?:.*\n){1}\s*Handle: *(.+)',

--- a/build/lib/whois/whois.py
+++ b/build/lib/whois/whois.py
@@ -273,6 +273,8 @@ class NICClient(object):
             return NICClient.DE_HOST
         elif tld == 'dev':
             return NICClient.DEV_HOST
+        elif tld == 'dk':
+            return NICClient.DK_HOST
         elif tld == 'do':
             return NICClient.DO_HOST
         elif tld == 'games':

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -2042,6 +2042,7 @@ class WhoisDk(WhoisEntry):
         'domain_name':            r'Domain: *(.+)',
         'creation_date':          r'Registered: *(.+)',
         'expiration_date':        r'Expires: *(.+)',
+        'registrar':              r'Registrar: *(.+)',
         'dnssec':                 r'Dnssec: *(.+)',
         'status':                 r'Status: *(.+)',
         'registrant_handle':      r'Registrant\s*(?:.*\n){1}\s*Handle: *(.+)',

--- a/whois/whois.py
+++ b/whois/whois.py
@@ -279,6 +279,8 @@ class NICClient(object):
             return NICClient.DE_HOST
         elif tld == 'dev':
             return NICClient.DEV_HOST
+        elif tld == 'dk':
+            return NICClient.DK_HOST
         elif tld == 'do':
             return NICClient.DO_HOST
         elif tld == 'games':


### PR DESCRIPTION
Ensure .dk domains get passed to the `WhoisDk` parser and host. Add the registrar regex, so that registrars are also picked up for `.dk` domains.