### PR TITLE
Update regex for UK NS parser

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -885,7 +885,7 @@ class WhoisUk(WhoisEntry):
         'expiration_date':                r'Expiry date:\s*(.+)',
         'updated_date':                   r'Last updated:\s*(.+)',
 
-        'name_servers':                   r'Name servers:\s*(.+)',
+        'name_servers':                   r'([\w.-]+\.(?:[\w-]+\.){1,2}[a-zA-Z]{2,}(?!\s+Relevant))\s+',
     }
 
     def __init__(self, domain, text):

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -885,7 +885,7 @@ class WhoisUk(WhoisEntry):
         'expiration_date':                r'Expiry date:\s*(.+)',
         'updated_date':                   r'Last updated:\s*(.+)',
 
-        'name_servers':                   r'([\w.-]+\.(?:[\w-]+\.){1,2}[a-zA-Z]{2,}(?!\s+Relevant))\s+',
+        'name_servers':                   r'([\w.-]+\.(?:[\w-]+\.){1,2}[a-zA-Z]{2,}(?!\s+Relevant|\s+Data))\s+',
     }
 
     def __init__(self, domain, text):


### PR DESCRIPTION
A quick change to the parser of NS for .UK domain names.

Currently, it only returns the first entry:

```
>>> from whois import whois
>>> whois("brixly.uk").name_servers
'justin.ns.cloudflare.com'
>>> whois("google.uk").name_servers
'ns1.googledomains.com'
```

Suggested change works with any number:

```
>>> from whois import whois
>>> whois("brixly.uk").name_servers
['justin.ns.cloudflare.com', 'mira.ns.cloudflare.com']
>>> whois("google.uk").name_servers
['ns1.googledomains.com', 'ns2.googledomains.com', 'ns3.googledomains.com', 'ns4.googledomains.com']
```