### PR TITLE
Complete the regex for parsing the WHOIS response results for .jp domains.

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -948,11 +948,11 @@ class WhoisJp(WhoisEntry):
     regex = {
         "domain_name": r".*\[Domain Name\]\s*(.+)",
         "registrant_org": r".*\[(?:Organization|Registrant)\](.+)",
-        "creation_date": r"\[(?:Registered Date|Created on)\]\s*(.+)",
-        "expiration_date": r"\[Expires on\]\s*(.+)",
+        "creation_date": r"\[(?:Registered Date|Created on|登録年月日)\]\s*(.+)",
+        "expiration_date": r"\[(?:Expires on|有効期限)\]\s*(.+)",
         "name_servers": r".*\[Name Server\]\s*(.+)",  # list of name servers
-        "updated_date": r"\[Last Updated?\]\s?(.+)",
-        "status": r"\[(?:State|Status)\]\s*(.+)",  # list of statuses
+        "updated_date": r"\[(?:Last Updated|最終更新)?\]\s?(.+)",
+        "status": r"\[(?:State|Status|状態)\]\s*(.+)",  # list of statuses
     }
 
     def __init__(self, domain, text):


### PR DESCRIPTION
yahoo-net.jp Some whois information of the domain name cannot be obtained.

WHOIS command.
```
Domain Information: [ドメイン情報]
[Domain Name]                   YAHOO-NET.JP

[登録者名]                      LINEヤフー株式会社
[Registrant]                    LY Corporation

[Name Server]                   ns01.yahoo.co.jp
[Name Server]                   ns02.yahoo.co.jp
[Name Server]                   ns11.yahoo.co.jp
[Name Server]                   ns12.yahoo.co.jp
[Signing Key]

[登録年月日]                    2008/08/29
[有効期限]                      2024/08/31
[状態]                          Active
[ロック状態]                    DomainTransferLocked
[ロック状態]                    AgentChangeLocked
[最終更新]                      2024/04/11 16:21:56 (JST)
```
