### PR TITLE
Fix regex for parsing .pl nameservers

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -730,7 +730,7 @@ class WhoisPl(WhoisEntry):
 
     regex = {
         "domain_name": r"DOMAIN NAME: *(.+)\n",
-        "name_servers": r"nameservers:((?:\s+.+\n+)*)",
+        "name_servers": r"nameservers:(?:\s+(\S+)\.[^\n]*\n)(?:\s+(\S+)\.[^\n]*\n)?(?:\s+(\S+)\.[^\n]*\n)?(?:\s+(\S+)\.[^\n]*\n)?", # up to 4
         "registrar": r"REGISTRAR:\s*(.+)",
         "registrar_url": r"URL: *(.+)",  # not available
         "status": r"Registration status:\n\s*(.+)",  # not available


### PR DESCRIPTION
.pl nameservers are not parsed correctly. Here is a fix.

Example: test.pl

Whois response:
~~~
$ whois test.pl

DOMAIN NAME:           test.pl
registrant type:       organization
nameservers:           dns.home.pl. [217.160.80.244][2001:8d8:fe:53:6870::1]
                       dns2.home.pl. [2001:8d8:fe:53:6870::2][217.160.81.248]
                       dns3.home.pl. [2607:f1c0:fe:53:185:132:34:251][185.132.34.251]
created:               1998.08.12 13:00:00
last modified:         2023.07.31 13:55:46
renewal date:          2024.08.11 14:00:00

option created:        2023.01.25 10:47:15
option expiration date:       2026.01.25 10:47:15

dnssec:                Unsigned


REGISTRAR:
cyber_Folks S.A.
ul. Franklina Roosevelta 22
60-829 Poznań
Polska/Poland
tel.: +48.122963663
info@domeny.pl

WHOIS database responses: https://dns.pl/en/whois

WHOIS displays data with a delay not exceeding 15 minutes in relation to the .pl Registry system

~~~

Before the change:
~~~
$ python
Python 3.11.8 (main, Feb 12 2024, 14:50:05) [GCC 13.2.1 20230801] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import whois
>>> print(whois.whois('test.pl'))
{
  "domain_name": "test.pl",
  "name_servers": "dns.home.pl. [217.160.80.244][2001:8d8:fe:53:6870::1]\r\r\n                       dns2.home.pl. [2001:8d8:fe:53:6870::2][217.160.81.248]\r\r\n                       dns3.home.pl. [2607:f1c0:fe:53:185:132:34:251][185.132.34.251]",
  "registrar": "cyber_Folks S.A.",
  "registrar_url": null,
  "status": null,
  "registrant_name": null,
  "creation_date": "1998-08-12 13:00:00",
  "expiration_date": "2024-08-11 14:00:00",
  "updated_date": "2023-07-31 13:55:46"
}
>>> 

~~~


After the change:
~~~
$ python
Python 3.11.8 (main, Feb 12 2024, 14:50:05) [GCC 13.2.1 20230801] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import whois
>>> print(whois.whois('test.pl'))
{
  "domain_name": "test.pl",
  "name_servers": [
    "dns.home.pl",
    "dns2.home.pl",
    "dns3.home.pl"
  ],
  "registrar": "cyber_Folks S.A.",
  "registrar_url": null,
  "status": null,
  "registrant_name": null,
  "creation_date": "1998-08-12 13:00:00",
  "expiration_date": "2024-08-11 14:00:00",
  "updated_date": "2023-07-31 13:55:46"
}
>>> 

>>> 

~~~