### PR TITLE
Fixed .jp updated_date domain_name and name_servers

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -6,12 +6,15 @@
 # This module is part of python-whois and is released under
 # the MIT license: http://www.opensource.org/licenses/mit-license.php
 
+import json
 import re
 from datetime import datetime, timezone
-from typing import Union, Dict
-import json
+from typing import Dict, Union
+
 import dateutil.parser as dp
+import pytz
 from dateutil.utils import default_tzinfo
+
 from .time_zones import tz_data
 
 EMAIL_REGEX = (
@@ -84,7 +87,9 @@ def cast_date(s, dayfirst=False, yearfirst=False):
     """Convert any date string found in WHOIS to a datetime object."""
     try:
         parsed_datetime = dp.parse(s, tzinfos=tz_data, dayfirst=dayfirst, yearfirst=yearfirst)
-        return default_tzinfo(parsed_datetime, timezone.utc)
+        # trancribe the timezone to UTC
+        original_datetime = default_tzinfo(parsed_datetime, timezone.utc)
+        return original_datetime.astimezone(pytz.utc).replace(tzinfo=None)
     except Exception:
         return datetime_parse(s)
 

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -10,9 +10,9 @@ import json
 import re
 from datetime import datetime, timezone
 from typing import Dict, Union
+from zoneinfo import ZoneInfo
 
 import dateutil.parser as dp
-import pytz
 from dateutil.utils import default_tzinfo
 
 from .time_zones import tz_data
@@ -89,7 +89,7 @@ def cast_date(s, dayfirst=False, yearfirst=False):
         parsed_datetime = dp.parse(s, tzinfos=tz_data, dayfirst=dayfirst, yearfirst=yearfirst)
         # trancribe the timezone to UTC
         original_datetime = default_tzinfo(parsed_datetime, timezone.utc)
-        return original_datetime.astimezone(pytz.utc).replace(tzinfo=None)
+        return original_datetime.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
     except Exception:
         return datetime_parse(s)
 


### PR DESCRIPTION
whois server return
```
[ JPRS database provides information on network administration. Its use is    ]
[ restricted to network administration purposes. For further information,     ]
[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]
Domain Information: [ドメイン情報]
a. [ドメイン名]                 YAHOO.CO.JP
e. [そしきめい]                 らいんやふーかぶしきがいしゃ
f. [組織名]                     LINEヤフー株式会社
g. [Organization]               LY Corporation
k. [組織種別]                   株式会社
l. [Organization Type]          Corporation
m. [登録担当者]                 HT57990JP
n. [技術連絡担当者]             YY47022JP
p. [ネームサーバ]               ns01.yahoo.co.jp
p. [ネームサーバ]               ns02.yahoo.co.jp
p. [ネームサーバ]               ns11.yahoo.co.jp
p. [ネームサーバ]               ns12.yahoo.co.jp
s. [署名鍵]
[状態]                          Connected (2024/09/30)
[ロック状態]                    AgentChangeLocked
[登録年月日]                    2019/09/27
[接続年月日]                    2019/09/27
[最終更新]                      2023/11/24 15:13:45 (JST)
```

fixed before
```
In [1]: import whois

In [2]: whois.whois("yahoo.co.jp")
Out[2]:
{'domain_name': None,
 'registrant_org': 'LY Corporation',
 'creation_date': datetime.datetime(2019, 9, 27, 0, 0),
 'expiration_date': None,
 'name_servers': None,
 'updated_date': '2023/11/24 15:13:45 (JST)',
 'status': 'Connected (2024/09/30)'}
```

fixed after
```
In [1]: import whois

In [2]: whois.whois("yahoo.co.jp")
Out[2]:
{'domain_name': 'YAHOO.CO.JP',
 'registrant_org': 'LY Corporation',
 'creation_date': datetime.datetime(2019, 9, 27, 0, 0, tzinfo=datetime.timezone.utc),
 'expiration_date': None,
 'name_servers': ['ns01.yahoo.co.jp',
  'ns02.yahoo.co.jp',
  'ns11.yahoo.co.jp',
  'ns12.yahoo.co.jp'],
 'updated_date': datetime.datetime(2023, 11, 24, 15, 13, 45, tzinfo=tzoffset('JST', 32400)),
 'status': 'Connected (2024/09/30)'}
```