### PR TITLE
Fixed .ru used correct nic server

### DIFF
--- a/whois/whois.py
+++ b/whois/whois.py
@@ -93,7 +93,7 @@ class NICClient(object):
     SNICHOST = "whois.6bone.net"
     WEBSITE_HOST = "whois.nic.website"
     ZA_HOST = "whois.registry.net.za"
-    RU_HOST = "whois.nic.ru"
+    RU_HOST = "whois.tcinet.ru"
     IDS_HOST = "whois.identitydigital.services"
     GDD_HOST = "whois.dnrs.godaddy"
     SHOP_HOST = "whois.nic.shop"


### PR DESCRIPTION
Fixed #207 
```
% TCI Whois Service. Terms of use:
% https://tcinet.ru/documents/whois_ru_rf.pdf (in Russian)
% https://tcinet.ru/documents/whois_su.pdf (in Russian)

domain:        WHOIS.RU
nserver:       jessica.ns.cloudflare.com.
nserver:       trey.ns.cloudflare.com.
state:         REGISTERED, DELEGATED, VERIFIED
org:           Domain name registrar SALENAMES LTD.
taxpayer-id:   7705693660
registrar:     SALENAMES-RU
admin-contact: https://partner.salenames.ru/contact_admin.khtml
created:       1999-05-14T13:58:12Z
paid-till:     2025-05-31T21:00:00Z
free-date:     2025-07-02
source:        TCI

Last updated on 2024-04-26T10:56:30Z
```

fixed after
```
{'domain_name': 'WHOIS.RU',
 'registrar': 'SALENAMES-RU',
 'creation_date': datetime.datetime(1999, 5, 14, 13, 58, 12),
 'expiration_date': datetime.datetime(2025, 5, 31, 21, 0),
 'name_servers': ['jessica.ns.cloudflare.com.', 'trey.ns.cloudflare.com.'],
 'status': 'REGISTERED, DELEGATED, VERIFIED',
 'emails': None,
 'org': 'Domain name registrar SALENAMES LTD.'}
```