### PR TITLE
Fix for #221

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -82,9 +82,10 @@ def datetime_parse(s):
 def cast_date(s, dayfirst=False, yearfirst=False):
     """Convert any date string found in WHOIS to a datetime object."""
     try:
+        # Use datetime.timezone.utc to support < Python3.9
         return default_tzinfo(dp.parse(
             s, tzinfos=tz_data, dayfirst=dayfirst, yearfirst=yearfirst
-        ), datetime.UTC)
+        ), datetime.timezone.utc)
     except Exception:
         return datetime_parse(s)
 


### PR DESCRIPTION
fix datetime.UTC, which doesn't work on all versions of Py3

I believe this was causing #221, because the date cast silently failed back to leaving the date as a string. I could be wrong, either way though this needed fixin' 
