### PR TITLE
Handle "before YYYY" entries

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -57,6 +57,7 @@ KNOWN_FORMATS = [
     "%d/%m/%Y %H:%M:%S.%f %Z",  # 23/04/2015 12:00:07.619546 EEST
     "%B %d %Y",  # August 14 2017
     "%d.%m.%Y %H:%M:%S",  # 08.03.2014 10:28:24
+    "before %Y",     # before 2001
     "before %b-%Y",  # before aug-1996
     "before %Y-%m-%d",  # before 1996-01-01
     "before %Y%m%d",  # before 19960821


### PR DESCRIPTION
Pretty trivial change, but it seems to work :)
Fixes #228 

Before:
```
>>> import whois
>>> whois.whois("ns.tomis.ro")
{'domain_name': 'tomis.ro', 'domain_status': 'OK', 'registrar': 'ICI - Registrar', 'referral_url': 'http://www.rotld.ro', 'creation_date': 'Before 2001', 'expiration_date': datetime.datetime(2028, 5, 29, 0, 0), 'name_servers': ['ns1.lucaservices.ro', 'ns2.lucaservices.ro'], 'status': 'OK', 'dnssec': 'Inactive'}
```
After:
```
>>> import whois
>>> whois.whois("ns.tomis.ro")
{'domain_name': 'tomis.ro', 'domain_status': 'OK', 'registrar': 'ICI - Registrar', 'referral_url': 'http://www.rotld.ro', 'creation_date': datetime.datetime(2001, 1, 1, 0, 0), 'expiration_date': datetime.datetime(2028, 5, 29, 0, 0), 'name_servers': ['ns1.lucaservices.ro', 'ns2.lucaservices.ro'], 'status': 'OK', 'dnssec': 'Inactive'}
```