### PR TITLE
Added the "Reseller" field to the parser.

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -100,6 +100,7 @@ class WhoisEntry(dict):
         "domain_name": r"Domain Name: *(.+)",
         "registrar": r"Registrar: *(.+)",
         "registrar_url": r"Registrar URL: *(.+)",
+        "reseller": r"Reseller: *(.+)",
         "whois_server": r"Whois Server: *(.+)",
         "referral_url": r"Referral URL: *(.+)",  # http url of whois_server
         "updated_date": r"Updated Date: *(.+)",


### PR DESCRIPTION
It's not a major change, just one line, but it adds the "reseller" field to the records, in case of need.  This can be useful to determine if a domain was purchased directly from the registrar, or from one of that registrar's resellers.