### PR TITLE
Small fixes for .AI, .SITE, .DESIGN parsers

### DIFF
--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -162,6 +162,9 @@ Domain Name: google.ai
 Registry Domain ID: 325702_nic_ai
 Registry WHOIS Server: whois.nic.ai
 Creation Date: 2017-12-16T05:37:20.801Z
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
 Registrar: Markmonitor
 Registrar Abuse Contact Email: ccops@markmonitor.com
 Registrar Abuse Contact Phone: +1.2083895740
@@ -266,6 +269,11 @@ DNSSEC: unsigned
             "tech_phone": "+1.6502530000",
             "tech_postal_code": "94043",
             "tech_state": "CA",
+            "status": [
+              "clientTransferProhibited https://icann.org/epp#clientTransferProhibited",
+              "clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited",
+              "clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited"
+            ],
         }
         self._parse_and_compare("google.ai", data, expected_results)
 

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -3341,7 +3341,7 @@ class WhoisSite(WhoisEntry):
         "whois_server": r"Whois Server: *(.+)",
         "updated_date": r"Updated Date: *(.+)",
         "creation_date": r"Creation Date: *(.+)",
-        "expiration_date": r"Registrar Registration Expiration Date: *(.+)",
+        "expiration_date": r"Registry Expiry Date: *(.+)",
         "name_servers": r"Name Server: *(.+)",  # list of name servers
         "status": r"Domain Status: *(.+)",  # list of statuses
         "emails": EMAIL_REGEX,  # list of email s
@@ -3371,7 +3371,7 @@ class WhoisDesign(WhoisEntry):
         "whois_server": r"Registrar WHOIS Server: *(.+)",
         "updated_date": r"Updated Date: *(.+)",
         "creation_date": r"Creation Date: *(.+)",
-        "expiration_date": r"Registrar Registration Expiration Date: *(.+)",
+        "expiration_date": r"Registry Expiry Date: *(.+)",
         "name_servers": r"Name Server: *(.+)",  # list of name servers
         "status": r"Domain Status: *(.+)",  # list of statuses
         "emails": EMAIL_REGEX,  # list of email s

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -2077,6 +2077,7 @@ class WhoisAi(WhoisEntry):
     regex = {
         "domain_name": r"Domain Name\s*:\s*(.+)",
         "domain_id": r"Registry Domain ID\s*:\s*(.+)",
+        "status": r"Domain Status:\s*(.+)",
         "creation_date": r"Creation Date:\s*(.+)",
         "registrar": r"Registrar:\s*(.+)",
         "registrar_phone": r"Registrar Abuse Contact Phone:\s*(.+)",


### PR DESCRIPTION
* Add status field regex to .AI parser

```py
Python 3.13.0 (main, Oct  8 2024, 00:00:00) [GCC 14.2.1 20240912 (Red Hat 14.2.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import whois
>>> w = whois.whois('tech.ai')
>>> w.status
'clientTransferProhibited https://icann.org/epp#clientTransferProhibited'
```
* Fix expiration date regex for .SITE and .DESIGN parsers

```py
Python 3.13.0 (main, Oct  8 2024, 00:00:00) [GCC 14.2.1 20240912 (Red Hat 14.2.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import whois
>>> w = whois.whois('good.design')
>>> w.expiration_date
datetime.datetime(2025, 12, 14, 18, 47, 53)
>>> w = whois.whois('secure.site')
>>> w.expiration_date
datetime.datetime(2025, 8, 2, 23, 59, 59)
```