### PR TITLE
Add ability to provide cli options in binary mode

### DIFF
--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -23,7 +23,7 @@ IPV4_OR_V6 = re.compile(
 )
 
 
-def whois(url, command=False, flags=0, executable="whois", inc_raw=False, quiet=False, convert_punycode=True):
+def whois(url, command=False, flags=0, executable="whois", executable_opts=[], inc_raw=False, quiet=False, convert_punycode=True):
     # clean domain to expose netloc
     ip_match = IPV4_OR_V6.match(url)
     if ip_match:
@@ -38,7 +38,7 @@ def whois(url, command=False, flags=0, executable="whois", inc_raw=False, quiet=
         domain = extract_domain(url)
     if command:
         # try native whois command
-        r = subprocess.Popen([executable, domain], stdout=subprocess.PIPE)
+        r = subprocess.Popen([executable] + executable_opts + ["--"] + [domain], stdout=subprocess.PIPE)
         text = r.stdout.read().decode()
     else:
         # try builtin client


### PR DESCRIPTION
Closes #257 

```py
Python 3.13.0 (main, Oct  8 2024, 00:00:00) [GCC 14.2.1 20240912 (Red Hat 14.2.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import whois
>>>
>>> w = whois.whois('aaaaaaaaabbbbbbbbbb.com', command=True, inc_raw=True)
>>> w.raw
'No match for domain "AAAAAAAAABBBBBBBBBB.COM".\n>>> Last update of whois database: 2024-12-26T09:13:55Z <<<\n\nNOTICE: The expiration date displayed in this record is the date the\nregistrar\'s sponsorship of the domain name registration in the registry is\ncurrently set to expire. This date does not necessarily reflect the expiration\ndate of the domain name registrant\'s agreement with the sponsoring\nregistrar.  Users may consult the sponsoring registrar\'s Whois database to\nview the registrar\'s reported date of expiration for this registration.\n\nTERMS OF USE: You are not authorized to access or query our Whois\ndatabase through the use of electronic processes that are high-volume and\nautomated except as reasonably necessary to register domain names or\nmodify existing registrations; the Data in VeriSign Global Registry\nServices\' ("VeriSign") Whois database is provided by VeriSign for\ninformation purposes only, and to assist persons in obtaining information\nabout or related to a domain name registration record. VeriSign does not\nguarantee its accuracy. By submitting a Whois query, you agree to abide\nby the following terms of use: You agree that you may use this Data only\nfor lawful purposes and that under no circumstances will you use this Data\nto: (1) allow, enable, or otherwise support the transmission of mass\nunsolicited, commercial advertising or solicitations via e-mail, telephone,\nor facsimile; or (2) enable high volume, automated, electronic processes\nthat apply to VeriSign (or its computer systems). The compilation,\nrepackaging, dissemination or other use of this Data is expressly\nprohibited without the prior written consent of VeriSign. You agree not to\nuse electronic processes that are automated and high-volume to access or\nquery the Whois database except as reasonably necessary to register\ndomain names or modify existing registrations. VeriSign reserves the right\nto restrict your access to the Whois database in its sole discretion to ensure\noperational stability.  VeriSign may restrict or terminate your access to the\nWhois database for failure to abide by these terms of use. VeriSign\nreserves the right to modify these terms at any time.\n\nThe Registry database contains ONLY .COM, .NET, .EDU domains and\nRegistrars.\n'
>>>
>>> w = whois.whois('aaaaaaaaabbbbbbbbbb.com', command=True, executable_opts=["-H"], inc_raw=True)
>>> w.raw
'No match for domain "AAAAAAAAABBBBBBBBBB.COM".\n>>> Last update of whois database: 2024-12-26T09:13:23Z <<<\n\nNOTICE: The expiration date displayed in this record is the date the\nregistrar\'s sponsorship of the domain name registration in the registry is\ncurrently set to expire. This date does not necessarily reflect the expiration\ndate of the domain name registrant\'s agreement with the sponsoring\nregistrar.  Users may consult the sponsoring registrar\'s Whois database to\nview the registrar\'s reported date of expiration for this registration.\n\n'
```