### PR TITLE
Fix name_server Attribute for BR domain

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1104,7 +1104,7 @@ class WhoisBr(WhoisEntry):
         "admin_c": r"admin-c: *(.+)",
         "tech_c": r"tech-c: *(.+)",
         "billing_c": r"billing-c: *(.+)",
-        "name_server": r"nserver: *(.+)",
+        "name_servers": r"nserver: *(.+)",
         "nsstat": r"nsstat: *(.+)",
         "nslastaa": r"nslastaa: *(.+)",
         "saci": r"saci: *(.+)",


### PR DESCRIPTION
The BR domain is using the "name_server" attribute in its regex whereas for all other domains the attribute is called "name_servers".

This PR is to standardize the BR domain to behave the same as all other domains and use the "name_servers" attribute name.