### PR TITLE
Adjust not found text for info domains

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1303,7 +1303,7 @@ class WhoisInfo(WhoisEntry):
     }
 
     def __init__(self, domain, text):
-        if text.strip() == "NOT FOUND":
+        if "Domain not found" in text:
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1104,7 +1104,7 @@ class WhoisBr(WhoisEntry):
         "admin_c": r"admin-c: *(.+)",
         "tech_c": r"tech-c: *(.+)",
         "billing_c": r"billing-c: *(.+)",
-        "name_server": r"nserver: *(.+)",
+        "name_servers": r"nserver: *(.+)",
         "nsstat": r"nsstat: *(.+)",
         "nslastaa": r"nslastaa: *(.+)",
         "saci": r"saci: *(.+)",


### PR DESCRIPTION
Apparently the return text for unregistered info domains has changed from "NOT FOUND" to "Domain not found".

This has been adjusted in class WhoisInfo accordingly