### PR TITLE
Adjust not found text for us domains

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -728,7 +728,7 @@ class WhoisUs(WhoisEntry):
     }
 
     def __init__(self, domain, text):
-        if "Not found:" in text:
+        if "No Data Found" in text:
             raise PywhoisError(text)
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)


### PR DESCRIPTION
Apparently the return text for unregistered us domains has changed from "Not  found" to "No Data Found".

This has been adjusted in class WhoisUs accordingly