### PR TITLE
Add UTF-8 encoding to whois file reading in tests

### DIFF
--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -59,7 +59,7 @@ class TestParser(unittest.TestCase):
         for path in glob(whois_path):
             # Parse whois data
             domain = os.path.basename(path)
-            with open(path) as whois_fp:
+            with open(path, encoding="utf-8") as whois_fp:
                 data = whois_fp.read()
 
             w = WhoisEntry.load(domain, data)


### PR DESCRIPTION
Without this change, I wasn't able to successfully run tests on Windows 10.
I got this error:
```
self = <encodings.cp1250.IncrementalDecoder object at 0x00000264F1DA8700>
input = b'% La informaci\xc3\xb3n a la que est\xc3\xa1s accediendo se provee exclusivamente para\r\n% fines relacionados con o...116.10/32)\r\nnserver:\tns2.afip.gov.ar (200.1.116.11/32)\r\nregistrar:\tnicar\r\ncreated:\t2016-06-30 22:15:47.314461'
final = True

    def decode(self, input, final=False):
>       return codecs.charmap_decode(input,self.errors,decoding_table)[0]
E       UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 398: character maps to <undefined>

C:\Users\Misiu\AppData\Local\Programs\Python\Python310\lib\encodings\cp1250.py:23: UnicodeDecodeError
=================================================================================================== short test summary info ==================================================================================================== 
FAILED test/test_parser.py::TestParser::test_com_allsamples - UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 398: character maps to <undefined>
```

All files in samples are UTF-8, so we can use this encoding while running tests.
I did not test on Linux!