### PR TITLE
Raise an exception on socket error

### DIFF
--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -33,6 +33,7 @@ def whois(
     executable_opts: Optional[list[str]] = None,
     inc_raw: bool = False,
     quiet: bool = False,
+    ignore_socket_errors: bool = True,
     convert_punycode: bool = True,
 ) -> dict[str, Any]:
     """
@@ -42,6 +43,7 @@ def whois(
     flags: flags to pass to the whois client (default 0)
     inc_raw: whether to include the raw text from whois in the result (default False)
     quiet: whether to avoid printing output (default False)
+    ignore_socket_errors: whether to ignore socket errors (default True)
     convert_punycode: whether to convert the given URL punycode (default True)
     """
     # clean domain to expose netloc
@@ -74,7 +76,7 @@ def whois(
         nic_client = NICClient()
         if convert_punycode:
             domain = domain.encode("idna").decode("utf-8")
-        text = nic_client.whois_lookup(None, domain, flags, quiet=quiet)
+        text = nic_client.whois_lookup(None, domain, flags, quiet=quiet, ignore_socket_errors=ignore_socket_errors)
     entry = WhoisEntry.load(domain, text)
     if inc_raw:
         entry["raw"] = text

--- a/whois/whois.py
+++ b/whois/whois.py
@@ -240,11 +240,11 @@ class NICClient:
             nhost = None
             response_str = response.decode("utf-8", "replace")
             if 'with "=xxx"' in response_str:
-                return self.whois(query, hostname, flags, True)
+                return self.whois(query, hostname, flags, True, quiet=quiet, ignore_socket_errors=ignore_socket_errors)
             if flags & NICClient.WHOIS_RECURSE and nhost is None:
                 nhost = self.findwhois_server(response_str, hostname, query)
             if nhost is not None and nhost != "":
-                response_str += self.whois(query, nhost, 0, quiet=True, ignore_socket_errors=ignore_socket_errors)
+                response_str += self.whois(query, nhost, 0, quiet=quiet, ignore_socket_errors=ignore_socket_errors)
         except socket.error as e:
             if not quiet:
                 logger.error(


### PR DESCRIPTION
Added optional flag `ignore_socket_errors: bool` to the `whois` method that allows to modify default handling of socket errors. With `ignore_socket_errors=False` whois will raise a socket exception instead of returning empty WHOIS data #277 .

Default is `ignore_socket_errors=True`.