### PR TITLE
.jp: handle JST timezone and expand creation_date pattern

### DIFF
--- a/test/samples/expected/titech.ac.jp
+++ b/test/samples/expected/titech.ac.jp
@@ -1,0 +1,1 @@
+{"domain_name": "TITECH.AC.JP", "expiration_date": null, "updated_date": "2025-05-29 10:45:59+09:00", "registrar": null, "registrar_url": null, "creation_date": null, "status": "Connected (2026/03/31)"}

--- a/test/samples/expected/yahoo.co.jp
+++ b/test/samples/expected/yahoo.co.jp
@@ -1,0 +1,1 @@
+{"domain_name": "YAHOO.CO.JP", "expiration_date": null, "updated_date": "2024-10-01 01:00:44+09:00", "registrar": null, "registrar_url": null, "creation_date": "2019-09-27 00:00:00", "status": "Connected (2025/09/30)"}

--- a/test/samples/whois/titech.ac.jp
+++ b/test/samples/whois/titech.ac.jp
@@ -1,0 +1,18 @@
+[ JPRS database provides information on network administration. Its use is    ]
+[ restricted to network administration purposes. For further information,     ]
+[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
+[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]
+Domain Information:
+a. [Domain Name]                TITECH.AC.JP
+g. [Organization]               Institute of Science Tokyo
+l. [Organization Type]          University
+m. [Administrative Contact]     YK87359JP
+n. [Technical Contact]          YS79730JP
+p. [Name Server]                ns.fujisawa.wide.ad.jp
+p. [Name Server]                titechns2-o.noc.titech.ac.jp
+p. [Name Server]                titechns2-s.noc.titech.ac.jp
+s. [Signing Key]
+[State]                         Connected (2026/03/31)
+[Registered Date]
+[Connected Date]                2025/05/26
+[Last Update]                   2025/05/29 10:45:59 (JST)

--- a/test/samples/whois/yahoo.co.jp
+++ b/test/samples/whois/yahoo.co.jp
@@ -1,0 +1,20 @@
+[ JPRS database provides information on network administration. Its use is    ]
+[ restricted to network administration purposes. For further information,     ]
+[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
+[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]
+Domain Information:
+a. [Domain Name]                YAHOO.CO.JP
+g. [Organization]               LY Corporation
+l. [Organization Type]          Corporation
+m. [Administrative Contact]     HT57990JP
+n. [Technical Contact]          YY47022JP
+p. [Name Server]                ns01.yahoo.co.jp
+p. [Name Server]                ns02.yahoo.co.jp
+p. [Name Server]                ns11.yahoo.co.jp
+p. [Name Server]                ns12.yahoo.co.jp
+s. [Signing Key]
+[State]                         Connected (2025/09/30)
+[Lock Status]                   AgentChangeLocked
+[Registered Date]               2019/09/27
+[Connected Date]                2019/09/27
+[Last Update]                   2024/10/01 01:00:44 (JST)

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -8,7 +8,7 @@
 
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from typing import Any, Callable, Optional, Union
 
 import dateutil.parser as dp
@@ -994,9 +994,8 @@ class WhoisJp(WhoisEntry):
     regex: dict[str, str] = {
         "domain_name": r"^(?:a\. )?\[Domain Name\]\s*(.+)",
         "registrant_org": r"^(?:g\. )?\[(?:Organization|Registrant)\](.+)",
-        # 'creation_date': r'\[(?:Registered Date|Created on)\]\s*(.+)',
+        "creation_date": r"\[(?:Registered Date|Created on)\][ \t]*(.+)",
         "organization_type": r"^(?:l\. )?\[Organization Type\]\s*(.+)$",
-        "creation_date": r"\[(?:Created on)\]\s*(.+)",
         "technical_contact_name": r"^(?:n. )?\[(?:Technical Contact)\]\s*(.+)",
         "administrative_contact_name": r"^(?:m. )?(?:\[Administrative Contact\]\s*(.+)|Contact Information:\s+^\[Name\](.*))",
         # These don't need the X. at the beginning, I just was too lazy to split the pattern off
@@ -1018,6 +1017,17 @@ class WhoisJp(WhoisEntry):
 
         super().__init__(domain, text, self.regex)
 
+    def _preprocess(self, attr, value):
+        # handle named timezone.  cast_date can't handle it, since datetime.parse doesn't support the format and
+        # strptime doesn't handle custom timezone names.
+        value = value.strip()
+        if value and isinstance(value, str) and "_date" in attr and value.endswith(" (JST)"):
+            value = value.replace(' (JST)', '')
+            value = cast_date(value, dayfirst=self.dayfirst, yearfirst=self.yearfirst)
+            value = value.replace(tzinfo=timezone(timedelta(seconds=tz_data['JST'])))
+            return value
+        else:
+            return super()._preprocess(attr, value)
 
 class WhoisAU(WhoisEntry):
     """Whois parser for .au domains"""


### PR DESCRIPTION
Times ending with ` (JST)` are parsed now, but it wasn't elegant, since `datetime.parse` doesn't support the rest of the format before the tz, and `strptime` only supports a few timezone names.

Also adjusted parsing of creation date, adding test cases both with and without a `[Registered Date]` field