### PR TITLE
Fix date parsing for .rs .kz .kg

### DIFF
--- a/test/samples/expected/abc.rs
+++ b/test/samples/expected/abc.rs
@@ -1,0 +1,1 @@
+{"domain_name": "abc.rs", "expiration_date": "2026-03-26 16:18:03+00:00", "updated_date": "2025-02-11 08:24:15+00:00", "registrar": "Mainstream Public Cloud Services d.o.o.", "registrar_url": null, "creation_date": "2008-03-26 16:18:03+00:00", "status": "Active https://www.rnids.rs/en/domain-name-status-codes#Active"}

--- a/test/samples/expected/google.kg
+++ b/test/samples/expected/google.kg
@@ -1,0 +1,1 @@
+{"domain_name": "GOOGLE.KG", "expiration_date": "2026-03-28 23:59:00+00:00", "updated_date": "2025-03-05 00:13:49+00:00", "registrar": null, "registrar_url": null, "creation_date": "2004-02-10 09:42:42+00:00", "status": null}

--- a/test/samples/expected/yandex.kz
+++ b/test/samples/expected/yandex.kz
@@ -1,0 +1,1 @@
+{"domain_name": "yandex.kz", "expiration_date": null, "updated_date": "2022-08-04 10:20:10+00:00", "registrar": "HOSTER.KZ", "registrar_url": null, "creation_date": "2009-07-01 12:44:02+00:00", "status": ["status : clientTransferProhibited", "clientDeleteProhibited", "clientRenewProhibited"]}

--- a/test/samples/whois/abc.rs
+++ b/test/samples/whois/abc.rs
@@ -1,0 +1,40 @@
+% The data in the Whois database are provided by RNIDS
+% for information purposes only and to assist persons in obtaining
+% information about or related to a domain name registration record.
+% Data in the database are created by registrants and we do not guarantee
+% their accuracy. We reserve the right to remove access
+% for entities abusing the data, without notice.
+% All timestamps are given in Serbian local time.
+%
+Domain name: abc.rs
+Domain status: Active https://www.rnids.rs/en/domain-name-status-codes#Active
+Registration date: 26.03.2008 16:18:03
+Modification date: 11.02.2025 08:24:15
+Expiration date: 26.03.2026 16:18:03
+Confirmed: 26.03.2008 16:18:03
+Registrar: Mainstream Public Cloud Services d.o.o.
+
+
+Registrant: Roda grupa doo
+Address: Bulevar Oslobodjenja 129, Beograd, Serbia
+Postal Code: 11000
+ID Number: 20886374
+Tax ID: 107867472
+
+Administrative contact: Individual
+
+Technical contact: SERBIA BROADBAND - SRPSKE KABLOVSKE MREZE D.O.O.
+Address: Bulevar Peka Dapcevica 19, Beograd, Serbia
+Postal Code: 11000
+ID Number: 17280554
+Tax ID: 101038731
+
+
+DNS: ns1.providus.rs - 164.132.48.70
+DNS: ns2.providus.rs - 104.199.179.254
+DNS: ns3.providus.rs - 52.5.196.189
+
+
+DNSSEC signed: no
+
+Whois Timestamp: 07.11.2025 20:57:08

--- a/test/samples/whois/google.kg
+++ b/test/samples/whois/google.kg
@@ -1,0 +1,40 @@
+% This is the .kg ccTLD Whois server
+% Register your own domain at https://www.cctld.kg
+% Whois web service - https://www.cctld.kg/whois
+
+Domain GOOGLE.KG (ACTIVE)
+
+Administrative Contact:
+   PID: AI-44973-KG
+   Name:
+   Address: United States Mountain View 1600 Amphitheatre Parkway N/A
+   Email: dns-admin@google.com
+   phone: 16502530000
+   fax: +1.6502530001
+
+Technical Contact:
+   PID: AI-44973-KG
+   Name:
+   Address: United States Mountain View 1600 Amphitheatre Parkway N/A
+   Email: dns-admin@google.com
+   phone: 16502530000
+   fax: +1.6502530001
+
+Billing Contact:
+   PID: 5935-KG
+   Name:
+   Address: United States Meridian 1120 S. Rackham Way Suite 300
+   Email: ccops@markmonitor.com
+   phone: +12083895740
+   fax: +12083895771
+
+
+Record created: Tue Feb 10 09:42:42 2004
+Record last updated on:  Wed Mar  5 00:13:49 2025
+Record expires on: Sat Mar 28 23:59:00 2026
+
+Name servers in the listed order:
+
+NS1.GOOGLE.COM
+NS2.GOOGLE.COM
+NS4.GOOGLE.COM

--- a/test/samples/whois/yandex.kz
+++ b/test/samples/whois/yandex.kz
@@ -1,0 +1,38 @@
+Whois Server for the KZ top level domain name.
+This server is maintained by KazNIC Organization, a ccTLD manager for Kazakhstan Republic.
+
+Domain Name............: yandex.kz
+
+Organization Using Domain Name
+Name...................: Yandex.Kazakhstan LLP
+Organization Name......: Yandex.Kazakhstan LLP
+Street Address.........: Dostyk street 43
+City...................: Almaty
+State..................: -
+Postal Code............: 050051
+Country................: KZ
+
+Administrative Contact/Agent
+NIC Handle.............: HOSTERKZ-280570
+Name...................: Domain manager
+Phone Number...........: +7.4957397000
+Fax Number.............: +7.4957397000
+Email Address..........: hostmaster@yandex.net
+
+Nameserver in listed order
+
+Primary server.........: ns1.yandex.net
+Primary ip address.....: 213.180.193.1
+
+Secondary server.......: ns2.yandex.net
+Secondary ip address...: 213.180.199.34
+
+
+Domain created: 2009-07-01 12:44:02 (GMT+0:00)
+Last modified : 2022-08-04 10:20:10 (GMT+0:00)
+Domain status : clientTransferProhibited - status prohibits domain transfer without documents (статус запрещает трансфер домена без предоставления документов)
+                clientDeleteProhibited - status prevent domain deletion from the Register (статус предотвращает удаление домена из реестра)
+                clientRenewProhibited - status prevent domain auto renewal without payment (статус предотвращает авто продление без оплаты)
+
+Registar created: KAZNIC
+Current Registar: HOSTER.KZ

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -45,7 +45,7 @@ class TestParser(unittest.TestCase):
 
     def test_unknown_date_format(self):
         with self.assertRaises(WhoisUnknownDateFormatError):
-            datetime_parse("UNKNOWN")
+            cast_date("UNKNOWN")
 
     def test_com_allsamples(self):
         """

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1730,8 +1730,8 @@ class WhoisKg(WhoisEntry):
         "name_servers": r"Name servers in the listed order: *([\d\w\.\s]+)",
         # 'name_servers':                 r'([\w]+\.[\w]+\.[\w]{2,5}\s*\d{1,3}\.\d]{1,3}\.[\d]{1-3}\.[\d]{1-3})',
         "creation_date": r"Record created: *(.+)",
-        "expiration_date": r"Record expires on \s*(.+)",
-        "updated_date": r"Record last updated on\s*(.+)",
+        "expiration_date": r"Record expires on:\s*(.+)",
+        "updated_date": r"Record last updated on:\s*(.+)",
     }
 
     def __init__(self, domain: str, text: str):

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -69,6 +69,7 @@ KNOWN_FORMATS: list[str] = [
     "before %Y-%m-%d",  # before 1996-01-01
     "before %Y%m%d",  # before 19960821
     "%Y-%m-%d %H:%M:%S (%Z%z)",  # 2017-09-26 11:38:29 (GMT+00:00)
+    "%Y-%m-%d %H:%M:%S (%Z+0:00)",  # 2009-07-01 12:44:02 (GMT+0:00)
     "%Y-%b-%d.",  # 2024-Apr-02.
 ]
 


### PR DESCRIPTION
The fix for .rs was a bit interesting.  It turns out we need to prefer our conversion function before `dateutil.parser`, because `dateutil.parser` does `%m.%d.%Y` and ours has `%d.%m.%Y` which is more logical.