### PR TITLE
Feature: Add Dual-Stack support with IPv6 preference

### DIFF
--- a/test/test_ipv6.py
+++ b/test/test_ipv6.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import patch
+import socket
+
+from whois.whois import NICClient
+
+
+class TestNICClientIPv6(unittest.TestCase):
+
+    def setUp(self):
+        self.ipv4_info = (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('1.2.3.4', 43))
+        self.ipv6_info = (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('2001:db8::1', 43, 0, 0))
+        self.mock_addr_info = [self.ipv4_info, self.ipv6_info]
+
+    @patch('socket.getaddrinfo')
+    @patch('socket.socket')
+    def test_connect_prioritizes_ipv6(self, mock_socket, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = self.mock_addr_info
+
+        client = NICClient(prefer_ipv6=True)
+        try:
+            client._connect("example.com", timeout=10)
+        except Exception:
+            pass
+
+        first_call_args = mock_socket.call_args_list[0][0]
+        # Make sure we used IPv6 when creating socket
+        self.assertEqual(first_call_args[0], socket.AF_INET6)
+
+    @patch('socket.getaddrinfo')
+    @patch('socket.socket')
+    def test_connect_keeps_default_order(self, mock_socket, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = self.mock_addr_info
+
+        client = NICClient(prefer_ipv6=False)
+        try:
+            client._connect("example.com", timeout=10)
+        except Exception:
+            pass
+
+        first_call_args = mock_socket.call_args_list[0][0]
+        # Make sure we used IPv4 when creating socket, which is the first appearing in our mock.
+        self.assertEqual(first_call_args[0], socket.AF_INET)


### PR DESCRIPTION
## Description

This PR modernizes the NICClient network logic by introducing Dual-Stack (IPv4/IPv6) support.

Previously, the library was forced to use `socket.AF_INET` (IPv4), making it unable to connect to WHOIS servers over IPv6 or leverage IPv6-only environments.

The core of this change is a refactoring of the connection logic into a centralized _connect method that uses `socket.getaddrinfo` with `socket.AF_UNSPEC`.

## Key Changes

- **Centralized Connection Logic:** Introduced `_connect(hostname, timeout)` to handle DNS resolution and connection attempts. This replaces the scattered `get_socket()` + `connect()` calls in `whois()` and `findwhois_iana()`.
- **IPv6 Preference:** Added a `prefer_ipv6` toggle in `NICClient.__init__`. When enabled, the client sorts resolved addresses to prioritize` AF_INET6` (IPv6) over `AF_INET` (IPv4).
- **Robust Fallback (Happy Eyeballs-ish):** If a connection to an IPv6 address fails (e.g., no route to host), the client automatically falls back to the next available address (IPv4) in the list.
- **CLI Exposure:** Added the `--prefer-ipv6` flag to the command-line interface.