### PR TITLE
Resolve AFNIC contacts (holder/admin/tech) and handle repeated roles

### DIFF
--- a/test/samples/expected/univ-paris8.fr
+++ b/test/samples/expected/univ-paris8.fr
@@ -1,0 +1,1 @@
+{"domain_name": "univ-paris8.fr", "expiration_date": "2026-12-31 23:00:00+00:00", "updated_date": "2026-01-31 23:05:07.728924+00:00", "registrar": "GIP RENATER", "registrar_url": null, "creation_date": "1994-12-31 23:00:00+00:00", "status": ["ACTIVE", "associated", "not identified", "ok"]}

--- a/test/samples/whois/univ-paris8.fr
+++ b/test/samples/whois/univ-paris8.fr
@@ -1,0 +1,129 @@
+%%
+%% This is the AFNIC Whois server.
+%%
+%% complete date format: YYYY-MM-DDThh:mm:ssZ
+%%
+%% Rights restricted by copyright.
+%% See https://www.afnic.fr/en/domain-names-and-support/everything-there-is-to-know-about-domain-names/find-a-domain-name-or-a-holder-using-whois/
+%%
+%%
+
+domain:                        univ-paris8.fr
+status:                        ACTIVE
+eppstatus:                     active
+hold:                          NO
+holder-c:                      UPH1-FRNIC
+admin-c:                       ANO00-FRNIC
+tech-c:                        CTC3167397-FRNIC
+tech-c:                        CTC3167398-FRNIC
+registrar:                     GIP RENATER
+Expiry Date:                   2026-12-31T23:00:00Z
+created:                       1994-12-31T23:00:00Z
+last-update:                   2026-01-31T23:05:07.728924Z
+source:                        FRNIC
+
+nserver:                       ns.univ-paris8.fr
+nserver:                       ns2.univ-paris8.fr
+source:                        FRNIC
+
+registrar:                     GIP RENATER
+address:                       Array
+address:                       75013 PARIS
+country:                       FR
+phone:                         +33.153942030
+fax-no:                        +33.153942031
+e-mail:                        domaine@renater.fr
+website:                       http://www.renater.fr
+anonymous:                     No
+registered:                    1997-12-29T00:00:00Z
+source:                        FRNIC
+
+nic-hdl:                       UPH1-FRNIC
+type:                          ORGANIZATION
+contact:                       Universite Paris 8
+address:                       Univ. Paris 8
+address:                       2, rue de la Liberte
+address:                       93526 Saint Denis
+country:                       FR
+phone:                         +33.149407026
+e-mail:                        dsi.secretariat@univ-paris8.fr
+registrar:                     GIP RENATER
+changed:                       2024-03-20T07:07:28.098152Z
+anonymous:                     NO
+obsoleted:                     NO
+eppstatus:                     associated
+eppstatus:                     active
+eligstatus:                    not identified
+reachstatus:                   not identified
+source:                        FRNIC
+
+nic-hdl:                       ANO00-FRNIC
+type:                          PERSON
+contact:                       Ano Nymous
+registrar:                     GIP RENATER
+changed:                       2026-05-11T16:03:06.594191Z
+anonymous:                     YES
+remarks:                       -------------- WARNING --------------
+remarks:                       While the registrar knows him/her,
+remarks:                       this person chose to restrict access
+remarks:                       to his/her personal data. So PLEASE,
+remarks:                       don't send emails to Ano Nymous. This
+remarks:                       address is bogus and there is no hope
+remarks:                       of a reply.
+remarks:                       -------------- WARNING --------------
+obsoleted:                     NO
+eppstatus:                     associated
+eppstatus:                     active
+eligstatus:                    not identified
+reachstatus:                   ok
+reachmedia:                    email
+reachsource:                   REGISTRAR
+reachdate:                     2024-03-20T07:07:51.613279Z
+source:                        FRNIC
+
+nic-hdl:                       CTC3167397-FRNIC
+type:                          PERSON
+contact:                       Jérôme TISSET
+address:                       Université de Paris 8
+address:                       2, rue de la Liberté
+address:                       93526 Saint Denis
+country:                       FR
+phone:                         +33.149407026
+e-mail:                        jerome.tisset@univ-paris8.fr
+registrar:                     GIP RENATER
+changed:                       2026-05-11T16:03:06.604163Z
+anonymous:                     NO
+obsoleted:                     NO
+eppstatus:                     associated
+eppstatus:                     active
+eligstatus:                    not identified
+reachstatus:                   ok
+reachmedia:                    email
+reachsource:                   REGISTRAR
+reachdate:                     2024-03-20T07:08:19.284269Z
+source:                        FRNIC
+
+nic-hdl:                       CTC3167398-FRNIC
+type:                          PERSON
+contact:                       Valerian MILLET
+address:                       Université de Paris 8
+address:                       2, rue de la Liberté
+address:                       93526 Saint Denis
+country:                       FR
+phone:                         +33.149407026
+e-mail:                        valerian.millet02@univ-paris8.fr
+registrar:                     GIP RENATER
+changed:                       2026-05-11T16:03:06.599168Z
+anonymous:                     NO
+obsoleted:                     NO
+eppstatus:                     associated
+eppstatus:                     active
+eligstatus:                    not identified
+reachstatus:                   ok
+reachmedia:                    email
+reachsource:                   REGISTRAR
+reachdate:                     2024-03-20T07:08:37.325169Z
+source:                        FRNIC
+
+>>> Last update of WHOIS database: 2026-05-21T21:53:52.954966Z <<<
+

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -838,6 +838,68 @@ compilation, repackaging, dissemination or other use of this Data is prohibited.
         }
         self._parse_and_compare("google.fr", data, expected_results)
 
+    def test_fr_multi_tech_contact_parse(self):
+        # AFNIC records may list a role more than once (issue #311):
+        # univ-paris8.fr has two tech-c handles pointing at distinct
+        # contacts. Resolving them must aggregate into lists instead of
+        # raising "TypeError: unhashable type: 'list'".
+        sample_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "samples",
+            "whois",
+            "univ-paris8.fr",
+        )
+        with open(sample_path, encoding="utf-8") as f:
+            data = f.read()
+
+        expected_results = {
+            "domain_name": "univ-paris8.fr",
+            "registrar": "GIP RENATER",
+            "creation_date": datetime.datetime(1994, 12, 31, 23, 0, tzinfo=utc),
+            "expiration_date": datetime.datetime(2026, 12, 31, 23, 0, tzinfo=utc),
+            "updated_date": datetime.datetime(
+                2026, 1, 31, 23, 5, 7, 728924, tzinfo=utc
+            ),
+            "name_servers": ["ns.univ-paris8.fr", "ns2.univ-paris8.fr"],
+            "status": ["ACTIVE", "associated", "not identified", "ok"],
+            "emails": [
+                "domaine@renater.fr",
+                "dsi.secretariat@univ-paris8.fr",
+                "jerome.tisset@univ-paris8.fr",
+                "valerian.millet02@univ-paris8.fr",
+            ],
+            "registrant_name": "Universite Paris 8",
+            "registrant_address": "Univ. Paris 8\n2, rue de la Liberte\n93526 Saint Denis",
+            "registrant_country": "FR",
+            "registrant_phone": "+33.149407026",
+            "registrant_email": "dsi.secretariat@univ-paris8.fr",
+            "registrant_type": "ORGANIZATION",
+            # Single admin-c handle -> scalar fields.
+            "admin_name": "Ano Nymous",
+            "admin_type": "PERSON",
+            # Two tech-c handles -> distinct values aggregate into lists,
+            # values shared by both contacts collapse back to scalars.
+            "tech_name": ["Jérôme TISSET", "Valerian MILLET"],
+            "tech_address": "Université de Paris 8\n2, rue de la Liberté\n93526 Saint Denis",
+            "tech_country": "FR",
+            "tech_phone": "+33.149407026",
+            "tech_email": [
+                "jerome.tisset@univ-paris8.fr",
+                "valerian.millet02@univ-paris8.fr",
+            ],
+            "tech_type": "PERSON",
+        }
+
+        results = WhoisEntry.load("univ-paris8.fr", data)
+        self.assertEqual(expected_results, results)
+
+        # Multi-handle role: distinct values become lists.
+        self.assertIsInstance(results["tech_name"], list)
+        self.assertIsInstance(results["tech_email"], list)
+        # Single-handle roles stay scalar.
+        self.assertIsInstance(results["registrant_name"], str)
+        self.assertIsInstance(results["admin_name"], str)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -1013,11 +1013,24 @@ class WhoisAfnic(WhoisEntry):
         contact_blocks = self._extract_contact_blocks(text)
 
         for handle, prefix in handle_to_prefix:
-            if handle and handle in contact_blocks:
-                for afnic_field, suffix in self._contact_field_mapping.items():
-                    value = contact_blocks[handle].get(afnic_field)
-                    if value is not None:
-                        self[f"{prefix}_{suffix}"] = value
+            if not handle:
+                continue
+            # A role may appear more than once (e.g. two tech-c lines), in
+            # which case WhoisEntry.parse() stores the field as a list.
+            handles = handle if isinstance(handle, list) else [handle]
+            for afnic_field, suffix in self._contact_field_mapping.items():
+                values: list[Any] = []
+                for single_handle in handles:
+                    block = contact_blocks.get(single_handle)
+                    if block is None:
+                        continue
+                    value = block.get(afnic_field)
+                    if value is not None and value not in values:
+                        values.append(value)
+                if len(values) == 1:
+                    self[f"{prefix}_{suffix}"] = values[0]
+                elif values:
+                    self[f"{prefix}_{suffix}"] = values
 
     @staticmethod
     def _extract_contact_blocks(text: str) -> dict[str, dict[str, Any]]:


### PR DESCRIPTION
## Summary
- AFNIC whois responses (.fr, .re, .pm, .tf, .wf, .yt) use a handle-reference system where `holder-c`, `admin-c`, and `tech-c` point to separate `nic-hdl` contact blocks. Each block is now resolved and mapped to `registrant_*`, `admin_*`, and `tech_*` fields (name, type, address, country, phone, email).
- Route all AFNIC TLDs (.re, .pm, .tf, .wf, .yt) to the parser, and rename `WhoisFr` to `WhoisAfnic`.
- Handle records that list a role more than once (e.g. two `tech-c:` lines): the resolved field is aggregated into a list instead of raising `TypeError: unhashable type: 'list'`.

Follow-up to https://github.com/richardpenman/whois/pull/311.
