### PR TITLE
Return None from cast_date() for "N/A" date values

### DIFF
--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -43,6 +43,10 @@ class TestParser(unittest.TestCase):
             r = cast_date(d).strftime("%Y-%m-%d")
             self.assertEqual(r, "2008-04-14")
 
+    def test_cast_date_not_applicable(self):
+        self.assertIsNone(cast_date("N/A"))
+        self.assertIsNone(cast_date("n/a"))
+
     def test_unknown_date_format(self):
         with self.assertRaises(WhoisUnknownDateFormatError):
             cast_date("UNKNOWN")

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -88,8 +88,12 @@ def datetime_parse(s: str) -> Union[datetime, None]:
 
 def cast_date(
     s: str, dayfirst: bool = False, yearfirst: bool = False
-) -> Union[str, datetime]:
+) -> Union[str, datetime, None]:
     """Convert any date string found in WHOIS to a datetime object."""
+
+    # explicit "not applicable" sentinel from some registries (e.g. CIRA .gc.ca)
+    if s.strip().upper() == "N/A":
+        return None
 
     # prefer our conversion before dateutil.parser
     # because dateutil.parser does %m.%d.%Y and ours has %d.%m.%Y which is more logical


### PR DESCRIPTION
## Summary

Fixes #315. Some registries (e.g. CIRA's `.gc.ca`) return a literal `N/A` in date fields. For `"N/A"`, dateutil raises a `ValueError`, not a `dp.ParserError`, so the narrow `except` in `cast_date()` doesn't catch it
and the error propagates out of `WhoisEntry.load()`, losing every other
field on the record.

Per the discussion in #315, `cast_date()` now returns `None` for this sentinel, the natural Python representation of "this date doesn't exist".

## Changes

- `whois/parser.py`: return `None` for the `"N/A"` sentinel (case-insensitive,
  trimmed); widen return annotation to `Union[str, datetime, None]`.
- `test/test_parser.py`: add `test_cast_date_not_applicable`.

Genuinely unrecognised formats still raise `WhoisUnknownDateFormatError`.