### PR TITLE
Normalize <br> HTML line breaks in WHOIS responses before parsing

### DIFF
--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -47,6 +47,26 @@ class TestParser(unittest.TestCase):
         self.assertIsNone(cast_date("N/A"))
         self.assertIsNone(cast_date("n/a"))
 
+    def test_br_separated_response(self):
+        data = (
+            "Updated Date: 2025-11-27T00:28:03Z<br>"
+            "Creation Date: 2002-01-23T04:00:00Z<br>"
+            "Registrar Registration Expiration Date: 2027-01-23T04:00:00Z<br>"
+            "Registrar: Onlinenic Inc<br>"
+        )
+        w = WhoisEntry.load("9966.org", data)
+        tz = datetime.timezone.utc
+        self.assertEqual(
+            w.updated_date, datetime.datetime(2025, 11, 27, 0, 28, 3, tzinfo=tz)
+        )
+        self.assertEqual(
+            w.creation_date, datetime.datetime(2002, 1, 23, 4, 0, 0, tzinfo=tz)
+        )
+        self.assertEqual(
+            w.expiration_date,
+            datetime.datetime(2027, 1, 23, 4, 0, 0, tzinfo=tz),
+        )
+
     def test_unknown_date_format(self):
         with self.assertRaises(WhoisUnknownDateFormatError):
             cast_date("UNKNOWN")

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -157,7 +157,7 @@ class WhoisEntry(dict):
             raise WhoisDomainNotFoundError(text)
         else:
             self.domain = domain
-            self.text = text
+            self.text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
             if regex is not None:
                 self._regex = regex
             if data_preprocessor is not None:


### PR DESCRIPTION
Some registrar WHOIS servers return their record as `text/html` with `<br>` as the line separator instead of newlines (e.g. OnlineNIC, `whois.onlinenic.com`):

```bash
$ whois -h whois.onlinenic.com 9966.org
lose
Content-Type: text/html

Domain Name: 9966.org<br>Registry Domain ID: <br>Registrar WHOIS Server: whois.onlinenic.com<br>Registrar URL: http://www.onlinenic.com<br>Updated Date: 2025-11-27T00:28:03Z<br>Creation Date: 2002-01-23T04:00:00Z<br>Registrar Registration Expiration Date: 2027-01-23T04:00:00Z<br>Registrar: Onlinenic Inc<br>Registrar IANA ID: 82<br>...

```

`WhoisEntry.parse()` runs its regexes with `re.M`, where `.` does not cross newlines — but here there are none, so `Updated Date: *(.+)` greedily captures the rest of the record and `cast_date()` raises `WhoisUnknownDateFormatError` (other fields are mangled too).

Fix: convert `<br>`, `<br/>` and `<br />` (case-insensitive) to newlines in `WhoisEntry.__init__` before any parsing, so the existing regexes and date formats work unchanged. The returned `raw` output is unaffected. Includes an end-to-end parse test; verified against the live `9966.org` record.