### PR TITLE
Added AUDA whois in for .au domains

### DIFF
--- a/whois/whois.py
+++ b/whois/whois.py
@@ -114,6 +114,7 @@ class NICClient:
     SBS_HOST = "whois.nic.sbs"
     GA_HOST = "whois.nic.ga"
     XYZ_HOST = "whois.nic.xyz"
+    AU_HOST = "whois.auda.org.au"
 
     SITE_HOST = "whois.nic.site"
     DESIGN_HOST = "whois.nic.design"
@@ -442,6 +443,8 @@ class NICClient:
             return NICClient.GA_HOST
         elif tld == "xyz":
             return NICClient.XYZ_HOST
+        elif tld == "au":
+             return NICClient.AU_HOST
         else:
             return self.findwhois_iana(tld, timeout=timeout)
             # server = tld + NICClient.QNICHOST_TAIL


### PR DESCRIPTION
Added in [whois.auda.org.au](https://whois.auda.org.au/) for all au TLDs
[auDA](https://www.auda.org.au/about-auda/) is Domain Administration for all .au domains 