### PR TITLE
Bound WHOIS response size and referral recursion depth (#312)

### DIFF
--- a/whois/whois.py
+++ b/whois/whois.py
@@ -123,6 +123,11 @@ class NICClient:
     WHOIS_RECURSE = 0x01
     WHOIS_QUICK = 0x02
 
+    # Hardening limits: bound resource use when talking to untrusted /
+    # referral whois servers.
+    MAX_WHOIS_RESPONSE = 10 * 1024 * 1024  # max bytes read from one server
+    MAX_REFERRAL_DEPTH = 10                 # max referral-chain recursion
+
     ip_whois: list[str] = [LNICHOST, RNICHOST, PNICHOST, BNICHOST, PANDIHOST]
 
     def __init__(self, prefer_ipv6: bool = False):
@@ -260,7 +265,8 @@ class NICClient:
         many_results: bool = False,
         quiet: bool = False,
         timeout: int = 10,
-        ignore_socket_errors: bool = True
+        ignore_socket_errors: bool = True,
+        _depth: int = 0
     ) -> str:
         """Perform initial lookup with TLD whois server
         then, if the quick flag is false, search that result
@@ -272,6 +278,8 @@ class NICClient:
         is `False`, will raise an exception instead of returning
         a string containing the error.
         """
+        if _depth > self.MAX_REFERRAL_DEPTH:
+            return ""
         response = b""
         s = None
         try:  # socket.connect in a try, in order to allow things like looping whois on different domains without
@@ -291,18 +299,20 @@ class NICClient:
             # recv returns bytes
             while True:
                 d = s.recv(4096)
-                response += d
                 if not d:
+                    break
+                response += d
+                if len(response) > self.MAX_WHOIS_RESPONSE:
                     break
 
             nhost = None
             response_str = response.decode("utf-8", "replace")
             if 'with "=xxx"' in response_str:
-                return self.whois(query, hostname, flags, True, quiet=quiet, ignore_socket_errors=ignore_socket_errors, timeout=timeout)
+                return self.whois(query, hostname, flags, True, quiet=quiet, ignore_socket_errors=ignore_socket_errors, timeout=timeout, _depth=_depth + 1)
             if flags & NICClient.WHOIS_RECURSE and nhost is None:
                 nhost = self.findwhois_server(response_str, hostname, query)
             if nhost is not None and nhost != "" and self._is_safe_referral_host(nhost):
-                response_str += self.whois(query, nhost, 0, quiet=quiet, ignore_socket_errors=ignore_socket_errors, timeout=timeout)
+                response_str += self.whois(query, nhost, 0, quiet=quiet, ignore_socket_errors=ignore_socket_errors, timeout=timeout, _depth=_depth + 1)
         except socket.error as e:
             if not quiet:
                 logger.error(


### PR DESCRIPTION
Adds two small hardening limits when talking to untrusted / referral whois
servers, addressing part of #312:

- MAX_WHOIS_RESPONSE (10 MB) — caps the recv loop so a malicious server can't
  force unbounded memory growth (CWE-400).
- MAX_REFERRAL_DEPTH (10) — caps referral-chain recursion so a chain of servers
  each referring onward can't trigger a RecursionError (CWE-674).

Both are conservative defaults and don't change behavior for normal lookups.
The regex-injection fix is in a separate PR; the SSRF item will follow.

Refs #312