### PR TITLE
Validate whois() query input before use (#312)

### DIFF
--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -43,6 +43,12 @@ def whois(
     convert_punycode: whether to convert the given URL punycode (default True)
     timeout: timeout for WHOIS request (default 10 seconds)
     """
+    if not isinstance(url, str) or not url.strip():
+        raise WhoisError("whois query must be a non-empty string")
+    if len(url) > 2048:
+        raise WhoisError("whois query is too long")
+    if any(ord(c) < 0x20 or ord(c) == 0x7f for c in url):
+        raise WhoisError("whois query contains control characters")
     # clean domain to expose netloc
     ip_match = IPV4_OR_V6.match(url)
     if ip_match:


### PR DESCRIPTION
Addresses the input-validation item (#5) in #312 (CWE-20).

The public whois() accepted arbitrary strings with no validation. Adds a
conservative sanity check at the entry point:
- reject empty / non-string input
- reject input longer than 2048 chars
- reject control characters (which could otherwise be injected into the whois
  wire protocol, since the query is sent to the server followed by CRLF)

Deliberately NOT strict RFC 1035 domain validation: whois() legitimately
accepts IPs, ASNs and network blocks, so domain-only validation would break
real lookups. This keeps those working while rejecting clearly-malformed input.

Refs #312